### PR TITLE
[synthetics] Add schemas for Continuous Testing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,7 @@
 
 # All your base
 *                       @DataDog/service-catalog
+
+## Subdirectories
+service-catalog         @DataDog/service-catalog
+datadog-ci              @DataDog/datadog-ci

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ JSON Schema is a vocabulary that allows you to annotate and validate JSON docume
     * Ensuring quality of client submitted data.
 
 # How’s JSON Schema used at Datadog?
-[Service Catalog](./service-catalog/README.md) is the first product that is actively leveraging JSON Schema at Datadog.
+
+Here is the list of products that are leveraging JSON Schema at Datadog:
+- [Service Catalog](./service-catalog/README.md) 
+- [Continuous Testing](./datadog-ci/README.md)
 
 # Datadog JSON Schemas in Schema Store 
 We have registered all Datadog JSON Schemas with the open source [Schema Store](https://www.schemastore.org/json/). By registering with Schema Store, we have added capability for the popular IDEs to auto complete and validate Datadog’s JSON Schemas.  

--- a/datadog-ci/README.md
+++ b/datadog-ci/README.md
@@ -1,0 +1,7 @@
+# Datadog CI
+
+JSON schemas that are defined in this directory are configuration files for [datadog-ci](https://github.com/DataDog/datadog-ci).
+
+Some configuration files are specific to a Datadog product. See the corresponding documentation for more details:
+
+- `synthetics`: [Continuous Testing](https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration?tab=npm) configuration

--- a/datadog-ci/datadog-ci.schema.json
+++ b/datadog-ci/datadog-ci.schema.json
@@ -1,0 +1,239 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "BasicAuthCredentials": {
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CookieSettings": {
+      "properties": {
+        "append": {
+          "description": "Whether to append or replace the original cookies.",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "Cookie header to add or replace (e.g. `name1=value1;name2=value2;`).",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ProxyConfiguration": {
+      "properties": {
+        "auth": {
+          "properties": {
+            "password": {
+              "type": "string"
+            },
+            "username": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "number"
+        },
+        "protocol": {
+          "$ref": "#/definitions/ProxyType"
+        }
+      },
+      "type": "object"
+    },
+    "ProxyType": {
+      "enum": [
+        "http",
+        "https",
+        "pac+data",
+        "pac+file",
+        "pac+ftp",
+        "pac+http",
+        "pac+https",
+        "socks",
+        "socks4",
+        "socks4a",
+        "socks5",
+        "socks5h"
+      ],
+      "type": "string"
+    },
+    "RetryConfig": {
+      "properties": {
+        "count": {
+          "description": "The number of attempts to perform in case of test failure.",
+          "type": "number"
+        },
+        "interval": {
+          "description": "The interval between attempts in milliseconds.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "UserConfigOverride": {
+      "properties": {
+        "allowInsecureCertificates": {
+          "description": "Disable certificate checks in Synthetic API tests.",
+          "type": "boolean"
+        },
+        "basicAuth": {
+          "$ref": "#/definitions/BasicAuthCredentials",
+          "description": "Credentials to provide if basic authentication is required."
+        },
+        "body": {
+          "description": "Data to send in an API test.",
+          "type": "string"
+        },
+        "bodyType": {
+          "description": "Content type for the data to send in an API test.",
+          "type": "string"
+        },
+        "cookies": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CookieSettings"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Use the provided string as a cookie header in an API or browser test (in addition or as a replacement).\n- If this is a string (e.g. `name1=value1;name2=value2;`), it is used to replace the original cookies.\n- If this is an object, it is used to either add to or replace the original cookies, depending on `append`."
+        },
+        "defaultStepTimeout": {
+          "description": "The maximum duration of steps in seconds for browser tests, which does not override individually set step timeouts.",
+          "type": "number"
+        },
+        "deviceIds": {
+          "description": "A list of devices to run the browser test on.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "executionRule": {
+          "description": "The execution rule for the test defines the behavior of the CLI in case of a failing test.\n- `blocking`: The CLI returns an error if the test fails.\n- `non_blocking`: The CLI only prints a warning if the test fails.\n- `skipped`: The test is not executed at all.",
+          "enum": ["blocking", "non_blocking", "skipped"],
+          "type": "string"
+        },
+        "followRedirects": {
+          "description": "Indicates whether or not to follow HTTP redirections in Synthetic API tests.",
+          "type": "boolean"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The headers to replace in the test. This object should contain keys as the name of the header to replace and values as the new value of the header to replace.",
+          "type": "object"
+        },
+        "locations": {
+          "description": "A list of locations to run the test from.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mobileApplicationVersion": {
+          "description": "The ID of an application version to run a Synthetic mobile application test on.",
+          "type": "string"
+        },
+        "mobileApplicationVersionFilePath": {
+          "description": "Upload an application as a temporary version for a Synthetic mobile application test.",
+          "type": "string"
+        },
+        "pollingTimeout": {
+          "description": "The maximum duration in milliseconds of a test. If the execution exceeds this value, it is considered failed.",
+          "type": "number"
+        },
+        "retry": {
+          "$ref": "#/definitions/RetryConfig",
+          "description": "The retry policy for the test."
+        },
+        "startUrl": {
+          "description": "The new start URL to provide to the test. Variables specified in brackets (for example, `{{ EXAMPLE }}`) found in environment variables are replaced.",
+          "type": "string"
+        },
+        "startUrlSubstitutionRegex": {
+          "description": "The regex to modify the starting URL of the test (for browser and HTTP tests only), whether it was given by the original test or the configuration override `startUrl`.",
+          "type": "string"
+        },
+        "variables": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The variables to replace in the test. This object should contain key as the name of the variable to replace and values as the new value of the variable to replace.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "apiKey": {
+      "description": "The API key used to query the Datadog API.",
+      "type": "string"
+    },
+    "appKey": {
+      "description": "The application key used to query the Datadog API.",
+      "type": "string"
+    },
+    "datadogSite": {
+      "description": "The Datadog instance to which request is sent.",
+      "type": "string"
+    },
+    "failOnCriticalErrors": {
+      "description": "A boolean flag that fails the CI job if no tests were triggered, or results could not be fetched from Datadog.",
+      "type": "boolean"
+    },
+    "failOnMissingTests": {
+      "description": "A boolean flag that fails the CI job if at least one specified test with a public ID is missing in a run (for example, if it has been deleted programmatically or on the Datadog site).",
+      "type": "boolean"
+    },
+    "failOnTimeout": {
+      "description": "A boolean flag that fails the CI job if at least one test exceeds the default test timeout.",
+      "type": "boolean"
+    },
+    "files": {
+      "description": "Glob patterns to detect Synthetic test configuration files (their well-known name is `*.synthetics.json`).",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "global": {
+      "$ref": "#/definitions/UserConfigOverride",
+      "description": "Overrides for Synthetic tests applied to all tests."
+    },
+    "pollingTimeout": {
+      "description": "The duration (in milliseconds) after which polling for test results is stopped.",
+      "type": "number"
+    },
+    "proxy": {
+      "$ref": "#/definitions/ProxyConfiguration",
+      "description": "The proxy to be used for outgoing connections to Datadog."
+    },
+    "subdomain": {
+      "description": "The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com`, the `subdomain` value needs to be set to `myorg`.",
+      "type": "string"
+    },
+    "testSearchQuery": {
+      "description": "Search query to select which Synthetic tests to run.",
+      "type": "string"
+    },
+    "tunnel": {
+      "description": "Use the Continuous Testing Tunnel to execute your test batch.",
+      "type": "boolean"
+    }
+  },
+  "type": "object"
+}

--- a/datadog-ci/synthetics/test-file.schema.json
+++ b/datadog-ci/synthetics/test-file.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "BasicAuthCredentials": {
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CookieSettings": {
+      "properties": {
+        "append": {
+          "description": "Whether to append or replace the original cookies.",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "Cookie header to add or replace (e.g. `name1=value1;name2=value2;`).",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "RetryConfig": {
+      "properties": {
+        "count": {
+          "description": "The number of attempts to perform in case of test failure.",
+          "type": "number"
+        },
+        "interval": {
+          "description": "The interval between attempts in milliseconds.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "TriggerConfig": {
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/UserConfigOverride",
+          "description": "Overrides for this Synthetic test only. This takes precedence over all other overrides."
+        },
+        "id": {
+          "description": "Public ID of a test (e.g. `abc-def-ghi`), or its full URL (e.g. `https://app.datadoghq.com/synthetics/details/abc-def-ghi`).",
+          "type": "string"
+        },
+        "suite": {
+          "description": "Name of a test suite (for JUnit reports).",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "UserConfigOverride": {
+      "properties": {
+        "allowInsecureCertificates": {
+          "description": "Disable certificate checks in Synthetic API tests.",
+          "type": "boolean"
+        },
+        "basicAuth": {
+          "$ref": "#/definitions/BasicAuthCredentials",
+          "description": "Credentials to provide if basic authentication is required."
+        },
+        "body": {
+          "description": "Data to send in an API test.",
+          "type": "string"
+        },
+        "bodyType": {
+          "description": "Content type for the data to send in an API test.",
+          "type": "string"
+        },
+        "cookies": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CookieSettings"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Use the provided string as a cookie header in an API or browser test (in addition or as a replacement).\n- If this is a string (e.g. `name1=value1;name2=value2;`), it is used to replace the original cookies.\n- If this is an object, it is used to either add to or replace the original cookies, depending on `append`."
+        },
+        "defaultStepTimeout": {
+          "description": "The maximum duration of steps in seconds for browser tests, which does not override individually set step timeouts.",
+          "type": "number"
+        },
+        "deviceIds": {
+          "description": "A list of devices to run the browser test on.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "executionRule": {
+          "description": "The execution rule for the test defines the behavior of the CLI in case of a failing test.\n- `blocking`: The CLI returns an error if the test fails.\n- `non_blocking`: The CLI only prints a warning if the test fails.\n- `skipped`: The test is not executed at all.",
+          "enum": ["blocking", "non_blocking", "skipped"],
+          "type": "string"
+        },
+        "followRedirects": {
+          "description": "Indicates whether or not to follow HTTP redirections in Synthetic API tests.",
+          "type": "boolean"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The headers to replace in the test. This object should contain keys as the name of the header to replace and values as the new value of the header to replace.",
+          "type": "object"
+        },
+        "locations": {
+          "description": "A list of locations to run the test from.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mobileApplicationVersion": {
+          "description": "The ID of an application version to run a Synthetic mobile application test on.",
+          "type": "string"
+        },
+        "mobileApplicationVersionFilePath": {
+          "description": "Upload an application as a temporary version for a Synthetic mobile application test.",
+          "type": "string"
+        },
+        "pollingTimeout": {
+          "description": "The maximum duration in milliseconds of a test. If the execution exceeds this value, it is considered failed.",
+          "type": "number"
+        },
+        "retry": {
+          "$ref": "#/definitions/RetryConfig",
+          "description": "The retry policy for the test."
+        },
+        "startUrl": {
+          "description": "The new start URL to provide to the test. Variables specified in brackets (for example, `{{ EXAMPLE }}`) found in environment variables are replaced.",
+          "type": "string"
+        },
+        "startUrlSubstitutionRegex": {
+          "description": "The regex to modify the starting URL of the test (for browser and HTTP tests only), whether it was given by the original test or the configuration override `startUrl`.",
+          "type": "string"
+        },
+        "variables": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The variables to replace in the test. This object should contain key as the name of the variable to replace and values as the new value of the variable to replace.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "tests": {
+      "items": {
+        "$ref": "#/definitions/TriggerConfig"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/service-catalog/README.md
+++ b/service-catalog/README.md
@@ -20,8 +20,8 @@ Check out our [onboarding guide](https://www.datadoghq.com) on how to get starte
 
 # Documentation 
 * [Product Overview](https://docs.datadoghq.com/tracing/faq/service_catalog/)
-* Setting up Service Catalog as an APM customer [Setting up Service Catalog as an APM * customer
-* Setting up Service Catalog as a non-APM customer [Setting up Service Catalog as a non-APM customer
+* Setting up Service Catalog as an APM customer
+* Setting up Service Catalog as a non-APM customer
 * Service Catalog API : Registering Services through the Datadog Service Definition API
 * Integrations 
 * JSON Schema Store 


### PR DESCRIPTION
This PR adds schemas to configure [Continuous Testing](https://docs.datadoghq.com/continuous_testing/).

The configuration files are meant to configure [`datadog-ci`](https://github.com/DataDog/datadog-ci) (used as a CLI, a library or via CI integrations).