### PR TITLE
[CI-APP] Add CI pipeline fingerprints field in Service Catalog schema v2.1

### DIFF
--- a/service-catalog/v2.1/schema.json
+++ b/service-catalog/v2.1/schema.json
@@ -109,6 +109,14 @@
 			"description": "Custom extensions",
 			"type": "object",
 			"additionalProperties": true
+		},
+		"ci-pipeline-fingerprints": {
+			"description": "A list of CI pipelines related the service",
+			"examples": ["f0p38w-7RcOM", "jfCEikXCdrIs"],
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		}
 	},
 	"additionalProperties": false,


### PR DESCRIPTION
Adds the `ci-pipeline-fingerprints` field in the Service Catalog schema v2.1.

Related PRs:
- https://github.com/DataDog/dd-go/pull/101523
- https://github.com/DataDog/infrastructure-resources/pull/1082
- https://github.com/DataDog/datadog-api-spec/pull/2364