### PR TITLE
[APM] Add semantic core JSON schema

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 
 # All your base
 *                       @DataDog/service-catalog
+
+/semantic-core/         @DataDog/semantic-core

--- a/semantic-core/.gitignore
+++ b/semantic-core/.gitignore
@@ -1,0 +1,163 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Custom semantic core generated files
+# schema.json

--- a/semantic-core/README.md
+++ b/semantic-core/README.md
@@ -1,0 +1,26 @@
+# semantic-core
+
+Playground repo for the Semantic Core
+
+## Setup
+
+```
+python3 -m venv venv
+source venv/bin/activate
+pip install pydantic
+```
+
+## Generate json schema
+
+This will output a schema.json file in the [VERSION] directory:
+
+```
+python3 gen_semantic_defs.py [VERSION]
+```
+
+Example:
+
+```
+python3 gen_semantic_defs.py v1
+```
+creates the `v1` directory if necessary, and writes the schema.json file.

--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -1,0 +1,27 @@
+import json
+import os
+from pydantic import BaseModel, Field
+
+class Fields(BaseModel):
+    hostname: str = Field(min_length=1)
+
+def generate_schema(version):
+    json_schema_str = json.dumps(Fields.model_json_schema(), indent=2)
+
+    # Create the directory if it doesn't exist
+    output_dir = os.path.join(os.getcwd(), version)
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Write the schema to the specified file
+    output_file = os.path.join(output_dir, "schema.json")
+    with open(output_file, "w") as f:
+        f.write(json_schema_str)
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate schema JSON file.")
+    parser.add_argument("version", type=str, help="Specify the version")
+
+    args = parser.parse_args()
+    generate_schema(version=args.version)

--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -1,5 +1,6 @@
 import json
 import os
+import logging
 from pydantic import BaseModel, Field
 
 class Fields(BaseModel):
@@ -20,8 +21,16 @@ def generate_schema(version):
 if __name__ == "__main__":
     import argparse
 
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
     parser = argparse.ArgumentParser(description="Generate schema JSON file.")
     parser.add_argument("version", type=str, help="Specify the version")
 
     args = parser.parse_args()
-    generate_schema(version=args.version)
+
+    try:
+        generate_schema(version=args.version)
+        logger.info(f"Schema successfully generated for version: {args.version}")
+    except Exception as e:
+        logger.error(f"Error generating schema: {e}")

--- a/semantic-core/v1/schema.json
+++ b/semantic-core/v1/schema.json
@@ -1,0 +1,14 @@
+{
+  "properties": {
+    "hostname": {
+      "minLength": 1,
+      "title": "Hostname",
+      "type": "string"
+    }
+  },
+  "required": [
+    "hostname"
+  ],
+  "title": "Fields",
+  "type": "object"
+}


### PR DESCRIPTION
Adds minimalist PoC to generate JSON schemas on the `semantic-core` directory.

From the README:

# semantic-core

Playground repo for the Semantic Core

## Setup

```
python3 -m venv venv
source venv/bin/activate
pip install pydantic
```

## Generate json schema

This will output a schema.json file in the [VERSION] directory:

```
python3 gen_semantic_defs.py [VERSION]
```

Example:

```
python3 gen_semantic_defs.py v1
```
creates the `v1` directory if necessary, and writes the schema.json file.
