### PR TITLE
Update schema of v2.2 to fix js to javascript

### DIFF
--- a/service-catalog/v2.2/schema.json
+++ b/service-catalog/v2.2/schema.json
@@ -50,7 +50,7 @@
 		},
 		"languages": {
 			"description": "The service's programming language. See examples for a list of recognizable languages",
-			"examples": [["dotnet", "go", "java", "js", "php", "python", "ruby", "c++"]],
+			"examples": [["dotnet", "go", "java", "javascript", "php", "python", "ruby", "c++"]],
 			"type": "array",
 			"items": {
 				"type": "string"


### PR DESCRIPTION
Updating schema of v2.2 to add to the list of array a correct id for JavaScript as `javascript`

Fixes #27