### PR TITLE
Fix required/optional fields in the generated json schema

### DIFF
--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -272,9 +272,9 @@ class IntakeResolvedSpan(BaseModel):
     ] = ...
 
 
-class TracerSpan(BaseModel):
+class AgentPayload(BaseModel):
     """
-    Represents the generic information present in a span that's produced by a tracer.
+    Represents the generic semantics for the agent payload, structurally defined here: https://github.com/DataDog/datadog-agent/blob/main/pkg/proto/datadog/trace/agent_payload.proto
     """
 
     hostname: Annotated[
@@ -322,7 +322,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     try:
-        payload_types = [IntakeResolvedSpan, IntakeResolvedHttpSpan, TracerSpan]
+        payload_types = [IntakeResolvedSpan, IntakeResolvedHttpSpan, AgentPayload]
 
         for pt in payload_types:
             generate_schema(pt, version=args.version)

--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -277,7 +277,7 @@ class AgentPayload(BaseModel):
     Represents the generic semantics for the agent payload, structurally defined here: https://github.com/DataDog/datadog-agent/blob/main/pkg/proto/datadog/trace/agent_payload.proto
     """
 
-    hostname: Annotated[
+    hostName: Annotated[
         Hostname,
         Field(
             default=None,
@@ -285,7 +285,7 @@ class AgentPayload(BaseModel):
             title="Hostname",
             description=textwrap.dedent(
                 """
-                The hostname of the host where the tracer is running."""
+                Hostname of where the agent is running."""
             ),
         ),
     ] = ...

--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import textwrap
-from typing import Optional
 
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
@@ -134,7 +133,7 @@ class IntakeResolvedHttpSpan(BaseModel):
                 Note: Although this is an integer, it must be sent as a string."""
             ),
         ),
-    ]
+    ] = ...
     http_url: Annotated[
         HttpUrl,
         Field(
@@ -145,7 +144,7 @@ class IntakeResolvedHttpSpan(BaseModel):
             The URL of the HTTP request, including the obfuscated query string."""
             ),
         ),
-    ]
+    ] = ...
     http_method: Annotated[
         HttpMethod,
         Field(
@@ -156,7 +155,7 @@ class IntakeResolvedHttpSpan(BaseModel):
             The HTTP method used for the connection. Required for both client and server spans."""
             ),
         ),
-    ]
+    ] = ...
     http_version: Annotated[
         HttpVersion,
         Field(
@@ -167,122 +166,129 @@ class IntakeResolvedHttpSpan(BaseModel):
             The version of HTTP used for the request."""
             ),
         ),
-    ]
-    http_route: Optional[
-        Annotated[
-            HttpRoute,
-            Field(
-                alias="http.route",
-                title="HTTP Route",
-                description=textwrap.dedent(
-                    """
+    ] = ...
+    http_route: Annotated[
+        HttpRoute,
+        Field(
+            alias="http.route",
+            title="HTTP Route",
+            description=textwrap.dedent(
+                """
             The matched route (path template).
             Only when span.kind: server."""
-                ),
             ),
-        ]
-    ]
-    http_client_ip: Optional[
-        Annotated[
-            IpAddress,
-            Field(
-                alias="http.client_ip",
-                title="HTTP Client IP",
-                description=textwrap.dedent(
-                    """
+        ),
+    ] = None
+    http_client_ip: Annotated[
+        IpAddress,
+        Field(
+            alias="http.client_ip",
+            title="HTTP Client IP",
+            description=textwrap.dedent(
+                """
             The IP address of the original client behind all proxies, if known (discovered from headers such as X-Forwarded-For)."""
-                ),
             ),
-        ]
-    ]
-    http_useragent: Optional[
-        Annotated[
-            HttpUserAgent,
-            Field(
-                alias="http.useragent",
-                title="HTTP User Agent",
-                description=textwrap.dedent(
-                    """
+        ),
+    ] = None
+    http_useragent: Annotated[
+        HttpUserAgent,
+        Field(
+            alias="http.useragent",
+            title="HTTP User Agent",
+            description=textwrap.dedent(
+                """
             The user agent header received with the request.
             Only when span.kind: server."""
-                ),
             ),
-        ]
-    ]
-    http_request_content_length: Optional[
-        Annotated[
-            HttpContentLength,
-            Field(
-                alias="http.request.content_length",
-                title="HTTP Request Content Length",
-                description=textwrap.dedent(
-                    """
+        ),
+    ] = None
+    http_request_content_length: Annotated[
+        HttpContentLength,
+        Field(
+            alias="http.request.content_length",
+            title="HTTP Request Content Length",
+            description=textwrap.dedent(
+                """
             The size of the request body.
             The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.
             For requests using transport encoding, this should be compressed size."""
-                ),
             ),
-        ]
-    ]
-    http_response_content_length: Optional[
-        Annotated[
-            HttpContentLength,
-            Field(
-                alias="http.response.content_length",
-                title="HTTP Response Content Length",
-                description=textwrap.dedent(
-                    """
+        ),
+    ] = None
+    http_response_content_length: Annotated[
+        HttpContentLength,
+        Field(
+            alias="http.response.content_length",
+            title="HTTP Response Content Length",
+            description=textwrap.dedent(
+                """
             The size of the response payload body in bytes.
             The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.
             For requests using transport encoding, this should be compressed size."""
-                ),
             ),
-        ]
-    ]
-    http_request_content_length_uncompressed: Optional[
-        Annotated[
-            HttpContentLength,
-            Field(
-                alias="http.request.content_length_uncompressed",
-                title="HTTP Request Content Length Uncompressed",
-                description=textwrap.dedent(
-                    """
+        ),
+    ] = None
+    http_request_content_length_uncompressed: Annotated[
+        HttpContentLength,
+        Field(
+            alias="http.request.content_length_uncompressed",
+            title="HTTP Request Content Length Uncompressed",
+            description=textwrap.dedent(
+                """
             The size of the request payload body after transport decoding. Not set if transport encoding not used."""
-                ),
             ),
-        ]
-    ]
-    http_response_content_length_uncompressed: Optional[
-        Annotated[
-            HttpContentLength,
-            Field(
-                alias="http.response.content_length_uncompressed",
-                title="HTTP Response Content Length Uncompressed",
-                description=textwrap.dedent(
-                    """
+        ),
+    ] = None
+    http_response_content_length_uncompressed: Annotated[
+        HttpContentLength,
+        Field(
+            alias="http.response.content_length_uncompressed",
+            title="HTTP Response Content Length Uncompressed",
+            description=textwrap.dedent(
+                """
             The size of the response payload body after transport decoding. Not set if transport encoding not used."""
-                ),
             ),
-        ]
-    ]
+        ),
+    ] = None
 
 
 class IntakeResolvedSpan(BaseModel):
-    hostname: Optional[
-        Annotated[
-            Hostname,
-            Field(
-                alias="_dd.hostname",
-                title="Hostname",
-                description=textwrap.dedent(
-                    """
+    """
+    Represents the generic information present in a span during intake.
+    """
+
+    hostname: Annotated[
+        Hostname,
+        Field(
+            alias="_dd.hostname",
+            title="Hostname",
+            description=textwrap.dedent(
+                """
                 When the DD_TRACE_REPORT_HOSTNAME=true environment variable, or report_hostname are set by the user the tracing clients will collect the hostname directly from the process or OS to report to the trace agent.
                 When _dd.hostname is present the trace agent will not use it’s hostname for the trace.
                 Note: this tag should only be set if configured to do so. It is disabled by default."""
-                ),
             ),
-        ]
-    ]
+        ),
+    ] = ...
+
+
+class TracerSpan(BaseModel):
+    """
+    Represents the generic information present in a span that's produced by a tracer.
+    """
+
+    hostname: Annotated[
+        Hostname,
+        Field(
+            default=None,
+            alias="hostName",
+            title="Hostname",
+            description=textwrap.dedent(
+                """
+                The hostname of the host where the tracer is running."""
+            ),
+        ),
+    ] = ...
 
 
 def generate_schema(payload_type, version):
@@ -316,7 +322,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     try:
-        payload_types = [IntakeResolvedSpan, IntakeResolvedHttpSpan]
+        payload_types = [IntakeResolvedSpan, IntakeResolvedHttpSpan, TracerSpan]
 
         for pt in payload_types:
             generate_schema(pt, version=args.version)

--- a/semantic-core/v1/agent_payload.json
+++ b/semantic-core/v1/agent_payload.json
@@ -2,7 +2,7 @@
   "description": "Represents the generic semantics for the agent payload, structurally defined here: https://github.com/DataDog/datadog-agent/blob/main/pkg/proto/datadog/trace/agent_payload.proto",
   "properties": {
     "hostName": {
-      "description": "\nThe hostname of the host where the tracer is running.",
+      "description": "\nHostname of where the agent is running.",
       "examples": [
         "my-hostname"
       ],

--- a/semantic-core/v1/agent_payload.json
+++ b/semantic-core/v1/agent_payload.json
@@ -1,5 +1,5 @@
 {
-  "description": "Represents the generic information present in a span that's produced by a tracer.",
+  "description": "Represents the generic semantics for the agent payload, structurally defined here: https://github.com/DataDog/datadog-agent/blob/main/pkg/proto/datadog/trace/agent_payload.proto",
   "properties": {
     "hostName": {
       "description": "\nThe hostname of the host where the tracer is running.",
@@ -15,6 +15,6 @@
   "required": [
     "hostName"
   ],
-  "title": "TracerSpan",
+  "title": "AgentPayload",
   "type": "object"
 }

--- a/semantic-core/v1/intake_resolved_http_span.json
+++ b/semantic-core/v1/intake_resolved_http_span.json
@@ -49,145 +49,89 @@
       "title": "HTTP Version",
       "type": "string"
     },
-    "http_route": {
-      "anyOf": [
-        {
-          "description": "\nThe matched route (path template).\nOnly when span.kind: server.",
-          "examples": [
-            "/users/:userID"
-          ],
-          "is_sensitive": false,
-          "minLength": 1,
-          "title": "HTTP Route",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
+    "http.route": {
+      "default": null,
+      "description": "\nThe matched route (path template).\nOnly when span.kind: server.",
+      "examples": [
+        "/users/:userID"
       ],
-      "title": "Http Route"
+      "is_sensitive": false,
+      "minLength": 1,
+      "title": "HTTP Route",
+      "type": "string"
     },
-    "http_client_ip": {
-      "anyOf": [
-        {
-          "description": "\nThe IP address of the original client behind all proxies, if known (discovered from headers such as X-Forwarded-For).",
-          "examples": [
-            "192.168.123.132"
-          ],
-          "is_sensitive": true,
-          "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$",
-          "title": "HTTP Client IP",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
+    "http.client_ip": {
+      "default": null,
+      "description": "\nThe IP address of the original client behind all proxies, if known (discovered from headers such as X-Forwarded-For).",
+      "examples": [
+        "192.168.123.132"
       ],
-      "title": "Http Client Ip"
+      "is_sensitive": true,
+      "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$",
+      "title": "HTTP Client IP",
+      "type": "string"
     },
-    "http_useragent": {
-      "anyOf": [
-        {
-          "description": "\nThe user agent header received with the request.\nOnly when span.kind: server.",
-          "examples": [
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
-          ],
-          "is_sensitive": true,
-          "minLength": 1,
-          "title": "HTTP User Agent",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
+    "http.useragent": {
+      "default": null,
+      "description": "\nThe user agent header received with the request.\nOnly when span.kind: server.",
+      "examples": [
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
       ],
-      "title": "Http Useragent"
+      "is_sensitive": true,
+      "minLength": 1,
+      "title": "HTTP User Agent",
+      "type": "string"
     },
-    "http_request_content_length": {
-      "anyOf": [
-        {
-          "description": "\nThe size of the request body.\nThe size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
-          "examples": [
-            1234
-          ],
-          "exclusiveMinimum": 0,
-          "is_sensitive": true,
-          "title": "HTTP Request Content Length",
-          "type": "integer"
-        },
-        {
-          "type": "null"
-        }
+    "http.request.content_length": {
+      "default": null,
+      "description": "\nThe size of the request body.\nThe size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
+      "examples": [
+        1234
       ],
-      "title": "Http Request Content Length"
+      "exclusiveMinimum": 0,
+      "is_sensitive": true,
+      "title": "HTTP Request Content Length",
+      "type": "integer"
     },
-    "http_response_content_length": {
-      "anyOf": [
-        {
-          "description": "\nThe size of the response payload body in bytes.\nThe size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
-          "examples": [
-            1234
-          ],
-          "exclusiveMinimum": 0,
-          "is_sensitive": true,
-          "title": "HTTP Response Content Length",
-          "type": "integer"
-        },
-        {
-          "type": "null"
-        }
+    "http.response.content_length": {
+      "default": null,
+      "description": "\nThe size of the response payload body in bytes.\nThe size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
+      "examples": [
+        1234
       ],
-      "title": "Http Response Content Length"
+      "exclusiveMinimum": 0,
+      "is_sensitive": true,
+      "title": "HTTP Response Content Length",
+      "type": "integer"
     },
-    "http_request_content_length_uncompressed": {
-      "anyOf": [
-        {
-          "description": "\nThe size of the request payload body after transport decoding. Not set if transport encoding not used.",
-          "examples": [
-            1234
-          ],
-          "exclusiveMinimum": 0,
-          "is_sensitive": true,
-          "title": "HTTP Request Content Length Uncompressed",
-          "type": "integer"
-        },
-        {
-          "type": "null"
-        }
+    "http.request.content_length_uncompressed": {
+      "default": null,
+      "description": "\nThe size of the request payload body after transport decoding. Not set if transport encoding not used.",
+      "examples": [
+        1234
       ],
-      "title": "Http Request Content Length Uncompressed"
+      "exclusiveMinimum": 0,
+      "is_sensitive": true,
+      "title": "HTTP Request Content Length Uncompressed",
+      "type": "integer"
     },
-    "http_response_content_length_uncompressed": {
-      "anyOf": [
-        {
-          "description": "\nThe size of the response payload body after transport decoding. Not set if transport encoding not used.",
-          "examples": [
-            1234
-          ],
-          "exclusiveMinimum": 0,
-          "is_sensitive": true,
-          "title": "HTTP Response Content Length Uncompressed",
-          "type": "integer"
-        },
-        {
-          "type": "null"
-        }
+    "http.response.content_length_uncompressed": {
+      "default": null,
+      "description": "\nThe size of the response payload body after transport decoding. Not set if transport encoding not used.",
+      "examples": [
+        1234
       ],
-      "title": "Http Response Content Length Uncompressed"
+      "exclusiveMinimum": 0,
+      "is_sensitive": true,
+      "title": "HTTP Response Content Length Uncompressed",
+      "type": "integer"
     }
   },
   "required": [
     "http.status_code",
     "http.url",
     "http.method",
-    "http.version",
-    "http_route",
-    "http_client_ip",
-    "http_useragent",
-    "http_request_content_length",
-    "http_response_content_length",
-    "http_request_content_length_uncompressed",
-    "http_response_content_length_uncompressed"
+    "http.version"
   ],
   "title": "IntakeResolvedHttpSpan",
   "type": "object"

--- a/semantic-core/v1/intake_resolved_span.json
+++ b/semantic-core/v1/intake_resolved_span.json
@@ -1,26 +1,19 @@
 {
+  "description": "Represents the generic information present in a span during intake.",
   "properties": {
-    "hostname": {
-      "anyOf": [
-        {
-          "description": "\nWhen the DD_TRACE_REPORT_HOSTNAME=true environment variable, or report_hostname are set by the user the tracing clients will collect the hostname directly from the process or OS to report to the trace agent.\nWhen _dd.hostname is present the trace agent will not use it\u2019s hostname for the trace.\nNote: this tag should only be set if configured to do so. It is disabled by default.",
-          "examples": [
-            "my-hostname"
-          ],
-          "is_sensitive": false,
-          "minLength": 0,
-          "title": "Hostname",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
+    "_dd.hostname": {
+      "description": "\nWhen the DD_TRACE_REPORT_HOSTNAME=true environment variable, or report_hostname are set by the user the tracing clients will collect the hostname directly from the process or OS to report to the trace agent.\nWhen _dd.hostname is present the trace agent will not use it\u2019s hostname for the trace.\nNote: this tag should only be set if configured to do so. It is disabled by default.",
+      "examples": [
+        "my-hostname"
       ],
-      "title": "Hostname"
+      "is_sensitive": false,
+      "minLength": 0,
+      "title": "Hostname",
+      "type": "string"
     }
   },
   "required": [
-    "hostname"
+    "_dd.hostname"
   ],
   "title": "IntakeResolvedSpan",
   "type": "object"

--- a/semantic-core/v1/tracer_span.json
+++ b/semantic-core/v1/tracer_span.json
@@ -1,0 +1,20 @@
+{
+  "description": "Represents the generic information present in a span that's produced by a tracer.",
+  "properties": {
+    "hostName": {
+      "description": "\nThe hostname of the host where the tracer is running.",
+      "examples": [
+        "my-hostname"
+      ],
+      "is_sensitive": false,
+      "minLength": 0,
+      "title": "Hostname",
+      "type": "string"
+    }
+  },
+  "required": [
+    "hostName"
+  ],
+  "title": "TracerSpan",
+  "type": "object"
+}


### PR DESCRIPTION
Rodrigo noticed a typo in "hostName" which led me down a rabbit hole to try and fix it. During said rabbit hole excursion I found out that our json schema was not being properly generated, specifically fields were not being correctly marked as required or optional.

This commit fixes that by adding `= ...` to required fields and `= None` for optional fields.

See: https://docs.pydantic.dev/latest/concepts/models/#required-fields

The generate json schema now includes a nested object that defines which fields are required (all others are optional):
```
 "required": [
    "hostName"
  ],
```

I've also added a new span representation for the tracer tests since these seem to have different keys when compared to the intake spans (we already expected to encounter cases like this).
