### PR TITLE
Semantic definitions for DB fields (take 2)

### DIFF
--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -125,6 +125,7 @@ DbSystem = Annotated[
 
 # Semantic Models
 
+
 class IntakeResolvedHttpSpan(BaseModel):
     """
     Semantic model for the HTTP information present in a span during intake.

--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -336,7 +336,6 @@ class IntakeResolvedDbSpan(BaseModel):
         Field(
             alias="db.system",
             title="DB System",
-            description=DbSystem.__metadata__[0].description
         )
     ] = ...
     db_connection_string: Annotated[
@@ -344,7 +343,6 @@ class IntakeResolvedDbSpan(BaseModel):
         Field(
             alias="db.connection_string",
             title="DB Connection String",
-            description=DbConnectionString.__metadata__[0].description
         )
     ] = None
     db_user: Annotated[
@@ -352,7 +350,6 @@ class IntakeResolvedDbSpan(BaseModel):
         Field(
             alias="db.user",
             title="DB User",
-            description=DbUser.__metadata__[0].description
         )
     ] = None
     db_name: Annotated[
@@ -360,7 +357,6 @@ class IntakeResolvedDbSpan(BaseModel):
         Field(
             alias="db.name",
             title="DB Name",
-            description=DbName.__metadata__[0].description
         )
     ] = None
     db_statement: Annotated[
@@ -368,7 +364,6 @@ class IntakeResolvedDbSpan(BaseModel):
         Field(
             alias="db.statement",
             title="DB Statement",
-            description=DbStatement.__metadata__[0].description
         )
     ] = None
     db_operation: Annotated[
@@ -376,7 +371,6 @@ class IntakeResolvedDbSpan(BaseModel):
         Field(
             alias="db.operation",
             title="DB Operation",
-            description=DbOperation.__metadata__[0].description
         )
     ] = None
     db_sql_table: Annotated[
@@ -384,7 +378,6 @@ class IntakeResolvedDbSpan(BaseModel):
         Field(
             alias="db.sql.table",
             title="DB SQL Table",
-            description=DbSqlTable.__metadata__[0].description
         )
     ] = None
     db_row_count: Annotated[
@@ -392,7 +385,6 @@ class IntakeResolvedDbSpan(BaseModel):
         Field(
             alias="db.row_count",
             title="DB Row Count",
-            description=DbRowCount.__metadata__[0].description
         )
     ] = None
 

--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -112,8 +112,18 @@ IpAddress = Annotated[
     ),
 ]
 
-# Semantic Models
+DbSystem = Annotated[
+    str,
+    Field(
+        description="""
+        An identifier for the database management system (DBMS) product being used.""",
+        examples=["mysql", "postgresql"],
+        pattern=r"^(adabas|buntdb|cache|cassandra|cloudscape|cockroachdb|coldfusion|consul|cosmosdb|couchbase|couchdb|db2|derby|dynamodb|edb|elasticsearch|eloquent|filemaker|firebird|firstsql|geode|h2|hanadb|hbase|hive|hsqldb|informix|ingres|instantdb|interbase|leveldb|mariadb|maxdb|memcached|mongodb|mssql|mysql|neo4j|netezza|opensearch|oracle|other_sql|pervasive|pointbase|postgresql|presto|progress|redis|redshift|snowflake|sqlite|sybase|teradata|vertica)$",
+        json_schema_extra={"is_sensitive": False},
+    ),
+]
 
+# Semantic Models
 
 class IntakeResolvedHttpSpan(BaseModel):
     """

--- a/semantic-core/v1/intake_resolved_db_span.json
+++ b/semantic-core/v1/intake_resolved_db_span.json
@@ -1,0 +1,89 @@
+{
+  "description": "Semantic model for the DB information present in a span during intake.",
+  "properties": {
+    "db.system": {
+      "description": "An identifier for the database management system (DBMS) product being used.",
+      "examples": [
+        "mysql",
+        "postgresql"
+      ],
+      "is_sensitive": false,
+      "pattern": "^(adabas|buntdb|cache|cassandra|cloudscape|cockroachdb|coldfusion|consul|cosmosdb|couchbase|couchdb|db2|derby|dynamodb|edb|elasticsearch|eloquent|filemaker|firebird|firstsql|geode|h2|hanadb|hbase|hive|hsqldb|informix|ingres|instantdb|interbase|leveldb|mariadb|maxdb|memcached|mongodb|mssql|mysql|neo4j|netezza|opensearch|oracle|other_sql|pervasive|pointbase|postgresql|presto|progress|redis|redshift|snowflake|sqlite|sybase|teradata|vertica)$",
+      "title": "DB System",
+      "type": "string"
+    },
+    "db.connection_string": {
+      "default": null,
+      "description": "The connection string used to connect to the database.",
+      "examples": [
+        "Server=(localdb)\u000b11.0;Integrated Security=true;",
+        "postgresql://localhost:5432"
+      ],
+      "is_sensitive": true,
+      "title": "DB Connection String",
+      "type": "string"
+    },
+    "db.user": {
+      "default": null,
+      "description": "Username for accessing the database.",
+      "examples": "widget_user",
+      "is_sensitive": false,
+      "title": "DB User",
+      "type": "string"
+    },
+    "db.name": {
+      "default": null,
+      "description": "The name of the database being connected to.",
+      "examples": "customers",
+      "is_sensitive": false,
+      "title": "DB Name",
+      "type": "string"
+    },
+    "db.statement": {
+      "default": null,
+      "description": "The database statement being executed.",
+      "examples": "SELECT * FROM wuser_table', 'SET mykey \"WuValue",
+      "is_sensitive": true,
+      "title": "DB Statement",
+      "type": "string"
+    },
+    "db.operation": {
+      "default": null,
+      "description": "The name of the operation being executed, e.g. the MongoDB command name such as findAndModify, or the SQL keyword.",
+      "examples": [
+        "findAndModify",
+        "HMSET",
+        "SELECT"
+      ],
+      "is_sensitive": false,
+      "title": "DB Operation",
+      "type": "string"
+    },
+    "db.sql.table": {
+      "default": null,
+      "description": "The name of the primary table that the operation is acting upon, including the database name (if applicable).",
+      "examples": [
+        "customers"
+      ],
+      "is_sensitive": false,
+      "title": "DB SQL Table",
+      "type": "string"
+    },
+    "db.row_count": {
+      "default": null,
+      "description": "\nThe number of rows/results from the query or operation. For caches and other datastores, i.e. Redis, this tag should only set for operations that retrieve stored data,\nsuch as GET operations and queries, excluding SET and other commands not returning data. ",
+      "examples": [
+        "customers"
+      ],
+      "is_sensitive": false,
+      "minimum": 0,
+      "title": "DB Row Count",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "db.system"
+  ],
+  "title": "IntakeResolvedDbSpan",
+  "type": "object"
+}


### PR DESCRIPTION
It looks like I broke the diff in the previous PR with a bad merge / rebase maybe? So here's a fixed branch.

I'm not a python expert by any-means but it seems like the trick I used to not have to copy-paste descriptions like:
`DbConnectionString.__metadata__[0].description` might be a better approach but looking for feedback? (Or maybe we actually want to decouple the descriptions? 🤔 )