### PR TITLE
[Semantic Core] SMTC-45: HTTP URL pattern check for no '?' character

### DIFF
--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -477,7 +477,22 @@ class AgentPayload(BaseModel):
     ] = ...
 
 
-class HttpTruncatedUrlAgentPayload(BaseModel):
+class HttpAgentPayload(BaseModel):
+    httpUrl: Annotated[
+        HttpUrl,
+        Field(
+            default=None,
+            alias="httpUrl",
+            title="HTTP URL",
+            description=textwrap.dedent(
+                """
+            The URL of the HTTP request, including the query string."""
+            ),
+        ),
+    ] = None
+
+
+class HttpRedactedAgentPayload(BaseModel):
     httpUrl: Annotated[
         TruncatedHttpUrl,
         Field(
@@ -486,7 +501,7 @@ class HttpTruncatedUrlAgentPayload(BaseModel):
             title="HTTP URL",
             description=textwrap.dedent(
                 """
-            The URL of the HTTP request, excluding the obfuscated query string."""
+            The URL of the HTTP request, excluding the query string."""
             ),
         ),
     ] = None
@@ -528,7 +543,8 @@ if __name__ == "__main__":
             IntakeResolvedHttpSpan,
             IntakeResolvedDbSpan,
             AgentPayload,
-            HttpTruncatedUrlAgentPayload,
+            HttpAgentPayload,
+            HttpRedactedAgentPayload,
         ]
 
         for pt in payload_types:

--- a/semantic-core/gen_semantic_defs.py
+++ b/semantic-core/gen_semantic_defs.py
@@ -35,7 +35,7 @@ Tags = Annotated[
     Field(
         description="""
         This field represents an arbitrary map of key-value pairs.""",
-        examples=[{"foo":"bar", "key":"value"}],
+        examples=[{"foo": "bar", "key": "value"}],
         json_schema_extra={"is_sensitive": False},
     ),
 ]
@@ -91,7 +91,7 @@ HttpUrl = Annotated[
         description="""
         The URL on an HTTP request, including the obfuscated query string.""",
         examples=["https://example.com:443/search?q=datadog"],
-        min_length=1,
+        pattern=r"^[^?]+$",
         json_schema_extra={"is_sensitive": True},
     ),
 ]
@@ -180,7 +180,10 @@ DbConnectionString = Annotated[
     str,
     Field(
         description="The connection string used to connect to the database.",
-        examples=["Server=(localdb)\v11.0;Integrated Security=true;","postgresql://localhost:5432"],
+        examples=[
+            "Server=(localdb)\v11.0;Integrated Security=true;",
+            "postgresql://localhost:5432",
+        ],
         json_schema_extra={"is_sensitive": True},
     ),
 ]
@@ -233,9 +236,11 @@ DbSqlTable = Annotated[
 DbRowCount = Annotated[
     int,
     Field(
-        description=textwrap.dedent("""
+        description=textwrap.dedent(
+            """
                                     The number of rows/results from the query or operation. For caches and other datastores, i.e. Redis, this tag should only set for operations that retrieve stored data,
-                                    such as GET operations and queries, excluding SET and other commands not returning data. """),
+                                    such as GET operations and queries, excluding SET and other commands not returning data. """
+        ),
         examples=["customers"],
         ge=0,
         json_schema_extra={"is_sensitive": False},
@@ -381,111 +386,44 @@ class IntakeResolvedHttpSpan(BaseModel):
         ),
     ] = None
 
+
 class IntakeResolvedDbSpan(BaseModel):
     """
     Semantic model for the DB information present in a span during intake.
     """
-    db_system: Annotated[
-        DbSystem,
-        Field(
-            alias="db.system",
-            title="DB System",
-        )
-    ] = ...
+
+    db_system: Annotated[DbSystem, Field(alias="db.system", title="DB System")] = ...
     db_connection_string: Annotated[
         DbConnectionString,
-        Field(
-            alias="db.connection_string",
-            title="DB Connection String",
-        )
+        Field(alias="db.connection_string", title="DB Connection String"),
     ] = None
-    db_user: Annotated[
-        DbUser,
-        Field(
-            alias="db.user",
-            title="DB User",
-        )
-    ] = None
-    db_name: Annotated[
-        DbName,
-        Field(
-            alias="db.name",
-            title="DB Name",
-        )
-    ] = None
+    db_user: Annotated[DbUser, Field(alias="db.user", title="DB User")] = None
+    db_name: Annotated[DbName, Field(alias="db.name", title="DB Name")] = None
     db_statement: Annotated[
-        DbStatement,
-        Field(
-            alias="db.statement",
-            title="DB Statement",
-        )
+        DbStatement, Field(alias="db.statement", title="DB Statement")
     ] = None
     db_operation: Annotated[
-        DbOperation,
-        Field(
-            alias="db.operation",
-            title="DB Operation",
-        )
+        DbOperation, Field(alias="db.operation", title="DB Operation")
     ] = None
     db_sql_table: Annotated[
-        DbSqlTable,
-        Field(
-            alias="db.sql.table",
-            title="DB SQL Table",
-        )
+        DbSqlTable, Field(alias="db.sql.table", title="DB SQL Table")
     ] = None
     db_row_count: Annotated[
-        DbRowCount,
-        Field(
-            alias="db.row_count",
-            title="DB Row Count",
-        )
+        DbRowCount, Field(alias="db.row_count", title="DB Row Count")
     ] = None
 
 
 class SpanLink(BaseModel):
-    traceID: Annotated[
-        TraceId,
-        Field(
-            alias="traceID",
-            title="Trace ID",
-        )
-    ] = ...
+    traceID: Annotated[TraceId, Field(alias="traceID", title="Trace ID")] = ...
     traceID_High: Annotated[
-        TraceId,
-        Field(
-            alias="traceID_High",
-            title="Trace ID High",
-        )
+        TraceId, Field(alias="traceID_High", title="Trace ID High")
     ] = None
-    spanID: Annotated[
-        SpanId,
-        Field(
-            alias="spanID",
-            title="Span ID",
-        )
-    ] = None
-    attributes: Annotated[
-        Tags,
-        Field(
-            alias="attributes",
-            title="attributes",
-        )
-    ] = None
+    spanID: Annotated[SpanId, Field(alias="spanID", title="Span ID")] = None
+    attributes: Annotated[Tags, Field(alias="attributes", title="attributes")] = None
     traceState: Annotated[
-        TraceState,
-        Field(
-            alias="traceState",
-            title="Trace State",
-        )
+        TraceState, Field(alias="traceState", title="Trace State")
     ] = None
-    flags: Annotated[
-        TraceFlags,
-        Field(
-            alias="flags",
-            title="Flags",
-        )
-    ] = None
+    flags: Annotated[TraceFlags, Field(alias="flags", title="Flags")] = None
 
 
 class IntakeResolvedSpan(BaseModel):
@@ -507,11 +445,7 @@ class IntakeResolvedSpan(BaseModel):
         ),
     ] = ...
     spanLinks: Annotated[
-        List[SpanLink],
-        Field(
-            alias="spanLinks",
-            title="Span Links",
-        )
+        List[SpanLink], Field(alias="spanLinks", title="Span Links")
     ] = None
 
 
@@ -565,7 +499,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     try:
-        payload_types = [IntakeResolvedSpan, IntakeResolvedHttpSpan, IntakeResolvedDbSpan, AgentPayload]
+        payload_types = [
+            IntakeResolvedSpan,
+            IntakeResolvedHttpSpan,
+            IntakeResolvedDbSpan,
+            AgentPayload,
+        ]
 
         for pt in payload_types:
             generate_schema(pt, version=args.version)

--- a/semantic-core/v1/http_agent_payload.json
+++ b/semantic-core/v1/http_agent_payload.json
@@ -1,0 +1,17 @@
+{
+  "properties": {
+    "httpUrl": {
+      "default": null,
+      "description": "\nThe URL of the HTTP request, including the query string.",
+      "examples": [
+        "https://example.com:443/search?q=datadog"
+      ],
+      "is_sensitive": true,
+      "minLength": 1,
+      "title": "HTTP URL",
+      "type": "string"
+    }
+  },
+  "title": "HttpAgentPayload",
+  "type": "object"
+}

--- a/semantic-core/v1/http_redacted_agent_payload.json
+++ b/semantic-core/v1/http_redacted_agent_payload.json
@@ -1,0 +1,18 @@
+{
+  "properties": {
+    "httpUrl": {
+      "default": null,
+      "description": "\nThe URL of the HTTP request, excluding the query string.",
+      "examples": [
+        "https://example.com:443/search"
+      ],
+      "is_sensitive": true,
+      "minLength": 1,
+      "pattern": "^[^?]+$",
+      "title": "HTTP URL",
+      "type": "string"
+    }
+  },
+  "title": "HttpRedactedAgentPayload",
+  "type": "object"
+}

--- a/semantic-core/v1/http_truncated_url_agent_payload.json
+++ b/semantic-core/v1/http_truncated_url_agent_payload.json
@@ -1,0 +1,18 @@
+{
+  "properties": {
+    "httpUrl": {
+      "default": null,
+      "description": "\nThe URL of the HTTP request, excluding the obfuscated query string.",
+      "examples": [
+        "https://example.com:443/search"
+      ],
+      "is_sensitive": true,
+      "minLength": 1,
+      "pattern": "^[^?]+$",
+      "title": "HTTP URL",
+      "type": "string"
+    }
+  },
+  "title": "HttpTruncatedUrlAgentPayload",
+  "type": "object"
+}

--- a/semantic-core/v1/intake_resolved_http_span.json
+++ b/semantic-core/v1/intake_resolved_http_span.json
@@ -19,7 +19,7 @@
         "https://example.com:443/search?q=datadog"
       ],
       "is_sensitive": true,
-      "pattern": "^[^?]+$",
+      "minLength": 1,
       "title": "HTTP URL",
       "type": "string"
     },

--- a/semantic-core/v1/intake_resolved_http_span.json
+++ b/semantic-core/v1/intake_resolved_http_span.json
@@ -19,7 +19,7 @@
         "https://example.com:443/search?q=datadog"
       ],
       "is_sensitive": true,
-      "minLength": 1,
+      "pattern": "^[^?]+$",
       "title": "HTTP URL",
       "type": "string"
     },


### PR DESCRIPTION
The intaking of HTTP query strings (potentially sensitive information) depends on [the implementation of each tracer](https://docs.datadoghq.com/tracing/configure_data_security/?tab=go#personal-information-in-trace-data) and [the configuration of the agents](https://docs.datadoghq.com/tracing/configure_data_security/?tab=go#redact-query-strings). 

With the current capabilities of the Semantic Core (a static json schema), we're unable to query for the information that we would need to validate HTTP URLs at intake time and ensure that, if applicable, no query strings should be present. 
For instance, we don't know what is the configuration of the agent from which we got a particular HTTP span, so we can't tell if it's configured to redact the query string or not. Yet another example is the current lack of expressiveness in our semantic definitions, which prevents us from stating rules such as "if this field was emitted from that tracer then apply rule X", ex: "if a payload containing an `http.url` field came from the Ruby tracer then it must not contain a query string".

This leaves us for now with just the tracer systems tests as a place where we can meaningfully test the presence/absence of the query string in an `http.url`, since there we can control and have access to all of the data that we would need to know if the query string should be present or not.

The trace semantic validator will keep looking just for the basic `HttpUrl` definition which only checks that the field is non empty.

To support these system tests this PR is adding:
* a new `TruncatedHttpUrl` semantic type that is a specialization of `HttpUrl` with the addition of a pattern that checks for the absence of the `?` character.
* a new `HttpRedactedAgentPayload` semantic model to be used in the system tests that expect a truncated query string on the `http.url` tag.
* a new `HttpAgentPayload` semantic model to be used in the system tests that expect the query string on the `http.url` tag to be present.