### PR TITLE
SMTC-49: Initial stab at defining a registry for the Semantic Properties

### DIFF
--- a/semantic-core/generation/gen_semantic_defs.py
+++ b/semantic-core/generation/gen_semantic_defs.py
@@ -11,6 +11,8 @@ from semantic_core.payloads import IntakeResolvedDbSpan
 from semantic_core.payloads import IntakeResolvedSpan
 from semantic_core.payloads import AgentPayload
 
+from semantic_core.registry import PropertiesRegistry
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -27,7 +29,6 @@ def generate_schema(*args, payload_type, version_info):
     snake_case_name = "".join(["_" + i.lower() if i.isupper() else i for i in payload_type.__name__]).lstrip("_")
 
     # Write the schema to the specified file
-    # output_file = os.path.join(output_dir, "schema.json")
     output_file = os.path.join(output_dir, f"{snake_case_name}.json")
     with open(output_file, "w") as f:
         f.write(json_schema_str)
@@ -59,7 +60,13 @@ def main():
         logger.info(f"New version: {new_version_info}")
 
         try:
-            payload_types = [IntakeResolvedSpan, IntakeResolvedHttpSpan, IntakeResolvedDbSpan, AgentPayload]
+            payload_types = [
+                IntakeResolvedSpan,
+                IntakeResolvedHttpSpan,
+                IntakeResolvedDbSpan,
+                AgentPayload,
+                PropertiesRegistry,
+            ]
 
             for pt in payload_types:
                 generate_schema(payload_type=pt, version_info=new_version_info)

--- a/semantic-core/generation/semantic_core/payloads/__init__.py
+++ b/semantic-core/generation/semantic_core/payloads/__init__.py
@@ -4,5 +4,4 @@ from .intake_resolved_http_span import IntakeResolvedHttpSpan
 from .intake_resolved_span import IntakeResolvedSpan
 
 
-
 __slots__ = ["AgentPayload", "IntakeResolvedDbSpan", "IntakeResolvedHttpSpan", "IntakeResolvedSpan"]

--- a/semantic-core/generation/semantic_core/registry/__init__.py
+++ b/semantic-core/generation/semantic_core/registry/__init__.py
@@ -1,0 +1,3 @@
+from .properties.properties_registry import PropertiesRegistry
+
+__slots__ = ["PropertiesRegistry"]

--- a/semantic-core/generation/semantic_core/registry/properties/data_policies.py
+++ b/semantic-core/generation/semantic_core/registry/properties/data_policies.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+from .util import prop
+
+
+class PoliciesEnum(str, Enum):
+    GDPR = "GDPR"
+    CCPA = "CCPA"
+    HIPAA = "HIPAA"
+
+
+DataPolicies = prop(
+    prop_type=list[PoliciesEnum],
+    description="""A list of data policies that apply to the associated field.""",
+    aspect="security",
+)

--- a/semantic-core/generation/semantic_core/registry/properties/is_sensitive.py
+++ b/semantic-core/generation/semantic_core/registry/properties/is_sensitive.py
@@ -1,0 +1,8 @@
+from .util import prop
+
+IsSensitive = prop(
+    prop_type=bool,
+    description="""Indicates if the field associated with this property contains sensitive data or not.""",
+    internal_description="""Sensitive data has some implications that T&S must define.""",
+    aspect="security",
+)

--- a/semantic-core/generation/semantic_core/registry/properties/properties_registry.py
+++ b/semantic-core/generation/semantic_core/registry/properties/properties_registry.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+from .data_policies import DataPolicies
+from .is_sensitive import IsSensitive
+
+
+class PropertiesRegistry(BaseModel):
+    """
+    Represents the registry of all Semantic Properties, i.e. the properties that can be used to define Semantic Types.
+    """
+
+    is_sensitive: IsSensitive
+    data_policies: DataPolicies

--- a/semantic-core/generation/semantic_core/registry/properties/util.py
+++ b/semantic-core/generation/semantic_core/registry/properties/util.py
@@ -1,0 +1,37 @@
+from typing import TypeVar, Type
+
+from pydantic import Field
+from typing_extensions import Annotated
+
+T = TypeVar("T")
+
+
+def prop(
+    prop_type: Type[T], description: str, aspect: str, internal_description: str = None, is_internal: bool = False
+):
+    """
+    This function produces a "property", represented as an extension of a base type (ex: int) with additional information
+    that describes the property itself.
+
+    :param prop_type: the base type of the property
+    :param description: the public description of the property, to be presented to Datadog's customers
+    :param internal_description:the internal description of the property, to be presented to Datadog's employees (may contain private/internal information)
+    :param aspect: the aspect of the property, used to group properties together and associate them to an owner
+    :param is_internal: whether the property is internal or not, hence if it should be exposed to in our public schemas or not
+    """
+
+    json_schema_extra = {
+        "aspect": aspect,
+        "is_internal": is_internal,
+    }
+
+    if internal_description is not None:
+        json_schema_extra["internal_description"] = internal_description
+
+    return Annotated[
+        prop_type,
+        Field(
+            description=description,
+            json_schema_extra=json_schema_extra,
+        ),
+    ]


### PR DESCRIPTION
This PR adds the concept of a "registry" as a [Pydantic class](https://docs.pydantic.dev/latest/concepts/models/#basic-model-usage) containing one field per [Semantic Property](https://docs.google.com/document/d/1dSgEMsCAV6PnNwRT5SRUEvUJz4rSyNDZ7PkbuYPQvXw/edit#heading=h.qt6gbw661gmg). This is so we can produce a JSON Schema for the registry itself, i.e. a machine readable format that we can then use to ensure the consistency of our component and payload models.

Each property is represented as a type with some extensions (via the usage of `Annotated`), following the Pydantic mechanisms we've been using so far in the Semantic Core.

I haven't created a new version of the schemas (not worth it until we stabilize these concepts), but I did create a draft which produced:
```
{
  "$defs": {
    "PoliciesEnum": {
      "enum": [
        "GDPR",
        "CCPA",
        "HIPAA"
      ],
      "title": "PoliciesEnum",
      "type": "string"
    }
  },
  "properties": {
    "is_sensitive": {
      "aspect": "security",
      "description": "Indicates if the field associated with this property contains sensitive data or not.",
      "internal_description": "Sensitive data has some implications that T&S must define.",
      "is_internal": false,
      "title": "Is Sensitive",
      "type": "boolean"
    },
    "data_policies": {
      "aspect": "security",
      "description": "Data policies that apply to the field.",
      "is_internal": false,
      "items": {
        "$ref": "#/$defs/PoliciesEnum"
      },
      "title": "Data Policies",
      "type": "array"
    }
  },
  "required": [
    "is_sensitive",
    "data_policies"
  ],
  "title": "PropertiesRegistry",
  "type": "object"
}
```