### PR TITLE
semantic-core: alternative version using cue

### DIFF
--- a/semantic-core/cue/Makefile
+++ b/semantic-core/cue/Makefile
@@ -1,0 +1,29 @@
+all: fmt vet schemas check-jsonschema
+.PHONY: all
+
+schemas: schemas/agent-payload schemas/span
+.PHONY: schemas
+
+schemas/agent-payload:
+	@mkdir -p gen/schemas && cue export . -e AgentPayload -o gen/schemas/agent_payload.json -f
+.PHONY: schemas/agent-payload
+
+schemas/span:
+	@mkdir -p gen/schemas && cue export . -e Span -o gen/schemas/span.json -f
+.PHONY: schemas/span
+
+fmt:
+	@cue fmt ./...
+.PHONY: fmt
+
+vet:
+	@cue vet ./... -c
+.PHONY: vet
+
+check-jsonschema:
+	@check-jsonschema --check-metaschema ./gen/schemas/*.json
+.PHONY: check-jsonschema
+
+fields:
+	@mkdir -p gen && cue export . -e Fields -o gen/fields.json -f
+.PHONY: fields

--- a/semantic-core/cue/README.md
+++ b/semantic-core/cue/README.md
@@ -1,0 +1,15 @@
+
+## Install
+
+```shell
+brew install cue check-jsonschema
+```
+
+
+## Generate definitions
+
+```shell
+make
+```
+
+JSON Schema fields will be generated under gen/schemas

--- a/semantic-core/cue/cue.mod/module.cue
+++ b/semantic-core/cue/cue.mod/module.cue
@@ -1,0 +1,1 @@
+module: "github.com/DataDog/schema"

--- a/semantic-core/cue/fields_common.cue
+++ b/semantic-core/cue/fields_common.cue
@@ -1,0 +1,22 @@
+package schema
+
+Fields: [string]: #Properties
+
+Fields: Common: {
+	"_dd.hostname": {
+		title:       "Hostname"
+		description: "Hostname of where the agent is running."
+		type:        "string"
+		default:     null
+		examples: [
+			"my-hostname",
+		]
+		minLength: 0
+	}
+	"span.kind": {
+		title:       "Span Kind"
+		description: "Span Kind"
+		type:        "string"
+		enum: ["client", "server", "producer", "consumer", "internal"]
+	}
+}

--- a/semantic-core/cue/fields_db.cue
+++ b/semantic-core/cue/fields_db.cue
@@ -1,0 +1,85 @@
+package schema
+
+Fields: DB: {
+	"db.system": {
+		"description": "An identifier for the database management system (DBMS) product being used."
+		"examples": [
+			"mysql",
+			"postgresql",
+		]
+		"type": "string"
+		// TODO: use enum feature instead of pattern.
+		"enum": ["adabas", "buntdb", "cache"]
+		// "pattern":      "^(adabas|buntdb|cache|cassandra|cloudscape|cockroachdb|coldfusion|consul|cosmosdb|couchbase|couchdb|db2|derby|dynamodb|edb|elasticsearch|eloquent|filemaker|firebird|firstsql|geode|h2|hanadb|hbase|hive|hsqldb|informix|ingres|instantdb|interbase|leveldb|mariadb|maxdb|memcached|mongodb|mssql|mysql|neo4j|netezza|opensearch|oracle|other_sql|pervasive|pointbase|postgresql|presto|progress|redis|redshift|snowflake|sqlite|sybase|teradata|vertica)$"
+		"title": "DB System"
+	}
+	"db.connection_string": {
+		"default":     null
+		"description": "The connection string used to connect to the database."
+		"examples": [
+			"Server=(localdb)\u000b11.0;Integrated Security=true;",
+			"postgresql://localhost:5432",
+		]
+		"is_sensitive": true
+		"title":        "DB Connection String"
+		"type":         "string"
+	}
+	"db.user": {
+		"default":     null
+		"description": "Username for accessing the database."
+		"examples": [
+			"widget_user",
+		]
+		"title": "DB User"
+		"type":  "string"
+	}
+	"db.name": {
+		"default":     null
+		"description": "The name of the database being connected to."
+		"examples": [
+			"customers",
+		]
+		"title": "DB Name"
+		"type":  "string"
+	}
+	"db.statement": {
+		"default":     null
+		"description": "The database statement being executed."
+		"examples": [
+			"SELECT * FROM wuser_table', 'SET mykey \"WuValue",
+		]
+		"is_sensitive": true
+		"title":        "DB Statement"
+		"type":         "string"
+	}
+	"db.operation": {
+		"default":     null
+		"description": "The name of the operation being executed, e.g. the MongoDB command name such as findAndModify, or the SQL keyword."
+		"examples": [
+			"findAndModify",
+			"HMSET",
+			"SELECT",
+		]
+		"title": "DB Operation"
+		"type":  "string"
+	}
+	"db.sql.table": {
+		"default":     null
+		"description": "The name of the primary table that the operation is acting upon, including the database name (if applicable)."
+		"examples": [
+			"customers",
+		]
+		"title": "DB SQL Table"
+		"type":  "string"
+	}
+	"db.row_count": {
+		"default":     null
+		"description": "\nThe number of rows/results from the query or operation. For caches and other datastores, i.e. Redis, this tag should only set for operations that retrieve stored data,\nsuch as GET operations and queries, excluding SET and other commands not returning data. "
+		"examples": [
+			"customers",
+		]
+		"minimum": 0
+		"title":   "DB Row Count"
+		"type":    "integer"
+	}
+}

--- a/semantic-core/cue/fields_http.cue
+++ b/semantic-core/cue/fields_http.cue
@@ -1,0 +1,125 @@
+package schema
+
+Fields: HTTP: {
+	"http.status_code": {
+		"description": "\nThe HTTP response status code.\nWhen span.kind: client the response status code received.\nWhen span.kind: server the response status code sent.\nNote: Although this is an integer, it must be sent as a string."
+		"examples": [
+			"200",
+			"404",
+			"500",
+		]
+		"pattern": "^[12345]\\d\\d$"
+		"title":   "HTTP Status Code"
+		"type":    "string"
+	}
+	"http.url": {
+		"description": "\nThe URL of the HTTP request, including the obfuscated query string."
+		"examples": [
+			"https://example.com:443/search?q=datadog",
+		]
+		"is_sensitive": true
+		"minLength":    1
+		"title":        "HTTP URL"
+		"type":         "string"
+	}
+	"http.method": {
+		"description": "\nThe HTTP method used for the connection. Required for both client and server spans."
+		"examples": [
+			"GET",
+			"POST",
+			"PUT",
+			"DELETE",
+			"PATCH",
+		]
+		"pattern": "^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH)$"
+		"title":   "HTTP Method"
+		"type":    "string"
+	}
+	"http.version": {
+		"description": "\nThe version of HTTP used for the request."
+		"examples": [
+			"1.0",
+			"1.1",
+			"2.0",
+		]
+		"pattern": "^1\\.[01]$|^2\\.0$"
+		"title":   "HTTP Version"
+		"type":    "string"
+	}
+	"http.route": {
+		"default":     null
+		"description": "\nThe matched route (path template).\nOnly when span.kind: server."
+		"examples": [
+			"/users/:userID",
+		]
+		"minLength": 1
+		"title":     "HTTP Route"
+		"type":      "string"
+	}
+	"http.client_ip": {
+		"default":     null
+		"description": "\nThe IP address of the original client behind all proxies, if known (discovered from headers such as X-Forwarded-For)."
+		"examples": [
+			"192.168.123.132",
+		]
+		"is_sensitive": true
+		"pattern":      "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$"
+		"title":        "HTTP Client IP"
+		"type":         "string"
+	}
+	"http.useragent": {
+		"default":     null
+		"description": "\nThe user agent header received with the request.\nOnly when span.kind: server."
+		"examples": [
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+		]
+		"is_sensitive": true
+		"minLength":    1
+		"title":        "HTTP User Agent"
+		"type":         "string"
+	}
+	"http.request.content_length": {
+		"default":     null
+		"description": "\nThe size of the request body.\nThe size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size."
+		"examples": [
+			1234,
+		]
+		"exclusiveMinimum": 0
+		"is_sensitive":     true
+		"title":            "HTTP Request Content Length"
+		"type":             "integer"
+	}
+	"http.response.content_length": {
+		"default":     null
+		"description": "\nThe size of the response payload body in bytes.\nThe size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size."
+		"examples": [
+			1234,
+		]
+		"exclusiveMinimum": 0
+		"is_sensitive":     true
+		"title":            "HTTP Response Content Length"
+		"type":             "integer"
+	}
+	"http.request.content_length_uncompressed": {
+		"default":     null
+		"description": "\nThe size of the request payload body after transport decoding. Not set if transport encoding not used."
+		"examples": [
+			1234,
+		]
+		"exclusiveMinimum": 0
+		"is_sensitive":     true
+		"title":            "HTTP Request Content Length Uncompressed"
+		"type":             "integer"
+	}
+	"http.response.content_length_uncompressed": {
+		"default":     null
+		"description": "\nThe size of the response payload body after transport decoding. Not set if transport encoding not used."
+		"examples": [
+			1234,
+		]
+		"exclusiveMinimum": 0
+		"is_sensitive":     true
+		"title":            "HTTP Response Content Length Uncompressed"
+		"type":             "integer"
+	}
+}

--- a/semantic-core/cue/gen/schemas/agent_payload.json
+++ b/semantic-core/cue/gen/schemas/agent_payload.json
@@ -1,0 +1,1031 @@
+{
+    "title": "AgentPayload",
+    "description": "Represents the generic semantics for the agent payload, structurally defined here: https://github.com/DataDog/datadog-agent/blob/main/pkg/proto/datadog/trace/agent_payload.proto",
+    "properties": {
+        "hostName": {
+            "title": "Hostname",
+            "description": "Hostname of where the agent is running.",
+            "type": "string",
+            "default": null,
+            "examples": [
+                "my-hostname"
+            ],
+            "minLength": 0,
+            "is_sensitive": false
+        },
+        "env": {
+            "default": null,
+            "description": "Specifies the 'env' set in the agent's configuration.",
+            "minLength": 1,
+            "title": "Env",
+            "type": "string",
+            "is_sensitive": false
+        },
+        "tags": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": null,
+            "description": "Tags specifies tags common in all `tracerPayloads`",
+            "title": "Tags",
+            "type": "object",
+            "is_sensitive": false
+        },
+        "agentVersion": {
+            "description": "Specifies version of the agent",
+            "minLength": 1,
+            "title": "Agent Version",
+            "type": "string",
+            "is_sensitive": false
+        },
+        "targetTPS": {
+            "description": "Holds `TargetTPS` value in AgentConfig",
+            "exclusiveMinimum": 0.0,
+            "title": "Target TPS",
+            "type": "number",
+            "is_sensitive": false
+        },
+        "errorTPS": {
+            "description": "Holds `ErrorTPS` value in AgentConfig",
+            "exclusiveMinimum": 0.0,
+            "title": "Error TPS",
+            "type": "number",
+            "is_sensitive": false
+        },
+        "rareSamplerEnabled": {
+            "default": null,
+            "description": "Holds `RareSamplerEnabled` value in AgentConfig",
+            "title": "Rare Sampler Flag",
+            "type": "boolean",
+            "is_sensitive": false
+        },
+        "tracerPayloads": {
+            "title": "Tracer Payloads",
+            "description": "Specifies the list of the payloads received from tracers",
+            "items": {
+                "$ref": "#/$defs/TracerPayload"
+            },
+            "type": "array",
+            "is_sensitive": false
+        }
+    },
+    "type": "object",
+    "required": [
+        "agentVersion",
+        "targetTPS",
+        "errorTPS",
+        "tracerPayloads"
+    ],
+    "$defs": {
+        "TracerPayload": {
+            "title": "TracerPayload",
+            "description": "Tracer Payload",
+            "type": "object",
+            "properties": {
+                "containerID": {
+                    "default": null,
+                    "description": "Specifies the ID of the container where the tracer is running on",
+                    "title": "Container ID",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "languageName": {
+                    "description": "Specifies the language of the tracer",
+                    "title": "Language Name",
+                    "type": "string",
+                    "enum": [
+                        "go",
+                        "python",
+                        "php",
+                        "ruby",
+                        "jvm",
+                        "dotnet",
+                        "js"
+                    ],
+                    "is_sensitive": false
+                },
+                "languageVersion": {
+                    "description": "Specifies the language version of the tracer",
+                    "title": "Language Version",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "tracerVersion": {
+                    "description": "Specifies the version of the tracer",
+                    "title": "Tracer Version",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "runtimeID": {
+                    "default": null,
+                    "description": "Specifies V4 UUID representation of a tracer session",
+                    "title": "Runtime ID",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "chunks": {
+                    "description": "Specifies the list of containing trace chunks",
+                    "items": {
+                        "$ref": "#/$defs/TraceChunk"
+                    },
+                    "title": "Trace Chunks",
+                    "type": "array",
+                    "is_sensitive": false
+                },
+                "tags": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": null,
+                    "description": "Specifies the list of tags common in all Trace Chunks",
+                    "title": "Trace Tags",
+                    "type": "object",
+                    "is_sensitive": false
+                },
+                "env": {
+                    "description": "Specifies the `env` tag that is set in the tracer configuration",
+                    "title": "Env",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "hostname": {
+                    "default": null,
+                    "description": "Specifies the hostname where the tracer is running",
+                    "title": "Hostname",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "appVersion": {
+                    "description": "Specifies the `version` tag that set in the tracer configuration",
+                    "title": "App Version",
+                    "type": "string",
+                    "is_sensitive": false
+                }
+            },
+            "required": [
+                "languageName",
+                "languageVersion",
+                "tracerVersion",
+                "chunks",
+                "env",
+                "appVersion"
+            ]
+        },
+        "TraceChunk": {
+            "title": "TraceChunk",
+            "description": "Trace Chunk",
+            "type": "object",
+            "properties": {
+                "priority": {
+                    "description": "Specifies the sampling priority of the trace",
+                    "title": "Priority",
+                    "type": "integer",
+                    "is_sensitive": false
+                },
+                "origin": {
+                    "default": null,
+                    "description": "Specifies the origin product (`lambda`, `rum`, etc.) of the trace",
+                    "title": "Origin",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "spans": {
+                    "description": "Specifies the list of containing spans",
+                    "items": {
+                        "$ref": "#/$defs/Span"
+                    },
+                    "title": "Spans",
+                    "type": "array",
+                    "is_sensitive": false
+                },
+                "tags": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": null,
+                    "description": "Specifies the list of tags common in all Spans",
+                    "title": "Tags",
+                    "type": "object",
+                    "is_sensitive": false
+                },
+                "droppedTrace": {
+                    "default": null,
+                    "description": "Specifies whether the trace was dropped by samplers or not",
+                    "title": "Dropped Trace",
+                    "type": "boolean",
+                    "is_sensitive": false
+                }
+            },
+            "required": [
+                "priority",
+                "spans"
+            ]
+        },
+        "BaseTags": {
+            "title": "Base Tags",
+            "description": "Base Tags",
+            "properties": {
+                "_dd.hostname": {
+                    "title": "Hostname",
+                    "description": "Hostname of where the agent is running.",
+                    "type": "string",
+                    "default": null,
+                    "examples": [
+                        "my-hostname"
+                    ],
+                    "minLength": 0,
+                    "is_sensitive": false
+                },
+                "span.kind": {
+                    "title": "Span Kind",
+                    "description": "Span Kind",
+                    "type": "string",
+                    "enum": [
+                        "client",
+                        "server",
+                        "producer",
+                        "consumer",
+                        "internal"
+                    ],
+                    "is_sensitive": false
+                }
+            },
+            "required": [
+                "span.kind"
+            ]
+        },
+        "HTTPTags": {
+            "title": "HTTP Meta Tags",
+            "description": "HTTP Meta Tags",
+            "properties": {
+                "_dd.hostname": {
+                    "title": "Hostname",
+                    "description": "Hostname of where the agent is running.",
+                    "type": "string",
+                    "default": null,
+                    "examples": [
+                        "my-hostname"
+                    ],
+                    "minLength": 0,
+                    "is_sensitive": false
+                },
+                "http.status_code": {
+                    "description": "\nThe HTTP response status code.\nWhen span.kind: client the response status code received.\nWhen span.kind: server the response status code sent.\nNote: Although this is an integer, it must be sent as a string.",
+                    "examples": [
+                        "200",
+                        "404",
+                        "500"
+                    ],
+                    "pattern": "^[12345]\\d\\d$",
+                    "title": "HTTP Status Code",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "http.url": {
+                    "description": "\nThe URL of the HTTP request, including the obfuscated query string.",
+                    "examples": [
+                        "https://example.com:443/search?q=datadog"
+                    ],
+                    "is_sensitive": true,
+                    "minLength": 1,
+                    "title": "HTTP URL",
+                    "type": "string"
+                },
+                "http.method": {
+                    "description": "\nThe HTTP method used for the connection. Required for both client and server spans.",
+                    "examples": [
+                        "GET",
+                        "POST",
+                        "PUT",
+                        "DELETE",
+                        "PATCH"
+                    ],
+                    "pattern": "^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH)$",
+                    "title": "HTTP Method",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "http.version": {
+                    "description": "\nThe version of HTTP used for the request.",
+                    "examples": [
+                        "1.0",
+                        "1.1",
+                        "2.0"
+                    ],
+                    "pattern": "^1\\.[01]$|^2\\.0$",
+                    "title": "HTTP Version",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "http.route": {
+                    "default": null,
+                    "description": "\nThe matched route (path template).\nOnly when span.kind: server.",
+                    "examples": [
+                        "/users/:userID"
+                    ],
+                    "minLength": 1,
+                    "title": "HTTP Route",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "http.client_ip": {
+                    "default": null,
+                    "description": "\nThe IP address of the original client behind all proxies, if known (discovered from headers such as X-Forwarded-For).",
+                    "examples": [
+                        "192.168.123.132"
+                    ],
+                    "is_sensitive": true,
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$",
+                    "title": "HTTP Client IP",
+                    "type": "string"
+                },
+                "http.useragent": {
+                    "default": null,
+                    "description": "\nThe user agent header received with the request.\nOnly when span.kind: server.",
+                    "examples": [
+                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                    ],
+                    "is_sensitive": true,
+                    "minLength": 1,
+                    "title": "HTTP User Agent",
+                    "type": "string"
+                },
+                "http.request.content_length": {
+                    "default": null,
+                    "description": "\nThe size of the request body.\nThe size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
+                    "examples": [
+                        1234
+                    ],
+                    "exclusiveMinimum": 0,
+                    "is_sensitive": true,
+                    "title": "HTTP Request Content Length",
+                    "type": "integer"
+                },
+                "http.response.content_length": {
+                    "default": null,
+                    "description": "\nThe size of the response payload body in bytes.\nThe size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
+                    "examples": [
+                        1234
+                    ],
+                    "exclusiveMinimum": 0,
+                    "is_sensitive": true,
+                    "title": "HTTP Response Content Length",
+                    "type": "integer"
+                },
+                "http.request.content_length_uncompressed": {
+                    "default": null,
+                    "description": "\nThe size of the request payload body after transport decoding. Not set if transport encoding not used.",
+                    "examples": [
+                        1234
+                    ],
+                    "exclusiveMinimum": 0,
+                    "is_sensitive": true,
+                    "title": "HTTP Request Content Length Uncompressed",
+                    "type": "integer"
+                },
+                "span.kind": {
+                    "title": "Span Kind",
+                    "description": "Span Kind",
+                    "type": "string",
+                    "enum": [
+                        "client",
+                        "server",
+                        "producer",
+                        "consumer",
+                        "internal"
+                    ],
+                    "is_sensitive": false
+                },
+                "http.response.content_length_uncompressed": {
+                    "default": null,
+                    "description": "\nThe size of the response payload body after transport decoding. Not set if transport encoding not used.",
+                    "examples": [
+                        1234
+                    ],
+                    "exclusiveMinimum": 0,
+                    "is_sensitive": true,
+                    "title": "HTTP Response Content Length Uncompressed",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "span.kind",
+                "http.status_code",
+                "http.url",
+                "http.method"
+            ]
+        },
+        "Span": {
+            "title": "Span",
+            "description": "Span",
+            "type": "object",
+            "properties": {
+                "service": {
+                    "description": "The name of the service with which this span is associated",
+                    "title": "Service",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "name": {
+                    "description": "The operation name of this span",
+                    "title": "Name",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "resource": {
+                    "description": "The resource name of this span, also sometimes called the endpoint (for web spans)",
+                    "title": "Resource",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "traceID": {
+                    "description": "The ID of the trace to which this span belongs",
+                    "title": "Trace ID",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "spanID": {
+                    "description": "The ID of this span",
+                    "title": "Span ID",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "parentID": {
+                    "default": null,
+                    "description": "The ID of this span's parent, or zero if this span has no parent",
+                    "title": "Parent ID",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "start": {
+                    "description": "The number of nanoseconds between the Unix epoch and the beginning of this span",
+                    "title": "Start",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "duration": {
+                    "description": "The time length of this span in nanoseconds",
+                    "title": "Duration",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "error": {
+                    "default": null,
+                    "description": "Error is 1 if there is an error associated with this span, or 0 if there is not",
+                    "title": "Error",
+                    "type": "integer",
+                    "is_sensitive": false
+                },
+                "meta": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": null,
+                    "description": "Meta is a mapping from tag name to tag value for string-valued tags",
+                    "title": "Meta",
+                    "type": "object",
+                    "is_sensitive": false
+                },
+                "metrics": {
+                    "additionalProperties": {
+                        "type": "number"
+                    },
+                    "default": null,
+                    "description": "Metrics is a mapping from tag name to tag value for numeric-valued tags",
+                    "title": "Metrics",
+                    "type": "object",
+                    "is_sensitive": false
+                },
+                "type": {
+                    "default": null,
+                    "description": "Represents the type of the service with which this span is associated. Example values: `web`, `db`, `lambda`",
+                    "title": "Type",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "meta_struct": {
+                    "additionalProperties": {
+                        "type": "integer"
+                    },
+                    "default": null,
+                    "description": "Represents a registry of structured \"other\" data used by, e.g., AppSec",
+                    "title": "Meta Struct",
+                    "type": "object",
+                    "is_sensitive": false
+                }
+            },
+            "required": [
+                "service",
+                "name",
+                "resource",
+                "traceID",
+                "spanID",
+                "start",
+                "duration"
+            ],
+            "allOf": [
+                {
+                    "if": {
+                        "not": {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "web",
+                                        "db"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "meta": {
+                                "$ref": "#/$defs/BaseTags"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "web"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "meta": {
+                                "$ref": "#/$defs/HTTPTags"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "db"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "meta": {
+                                "$ref": "#/$defs/DBTags"
+                            }
+                        }
+                    }
+                }
+            ],
+            "$defs": {
+                "BaseTags": {
+                    "title": "Base Tags",
+                    "description": "Base Tags",
+                    "properties": {
+                        "_dd.hostname": {
+                            "title": "Hostname",
+                            "description": "Hostname of where the agent is running.",
+                            "type": "string",
+                            "default": null,
+                            "examples": [
+                                "my-hostname"
+                            ],
+                            "minLength": 0,
+                            "is_sensitive": false
+                        },
+                        "span.kind": {
+                            "title": "Span Kind",
+                            "description": "Span Kind",
+                            "type": "string",
+                            "enum": [
+                                "client",
+                                "server",
+                                "producer",
+                                "consumer",
+                                "internal"
+                            ],
+                            "is_sensitive": false
+                        }
+                    },
+                    "required": [
+                        "span.kind"
+                    ]
+                },
+                "HTTPTags": {
+                    "title": "HTTP Meta Tags",
+                    "description": "HTTP Meta Tags",
+                    "properties": {
+                        "_dd.hostname": {
+                            "title": "Hostname",
+                            "description": "Hostname of where the agent is running.",
+                            "type": "string",
+                            "default": null,
+                            "examples": [
+                                "my-hostname"
+                            ],
+                            "minLength": 0,
+                            "is_sensitive": false
+                        },
+                        "http.status_code": {
+                            "description": "\nThe HTTP response status code.\nWhen span.kind: client the response status code received.\nWhen span.kind: server the response status code sent.\nNote: Although this is an integer, it must be sent as a string.",
+                            "examples": [
+                                "200",
+                                "404",
+                                "500"
+                            ],
+                            "pattern": "^[12345]\\d\\d$",
+                            "title": "HTTP Status Code",
+                            "type": "string",
+                            "is_sensitive": false
+                        },
+                        "http.url": {
+                            "description": "\nThe URL of the HTTP request, including the obfuscated query string.",
+                            "examples": [
+                                "https://example.com:443/search?q=datadog"
+                            ],
+                            "is_sensitive": true,
+                            "minLength": 1,
+                            "title": "HTTP URL",
+                            "type": "string"
+                        },
+                        "http.method": {
+                            "description": "\nThe HTTP method used for the connection. Required for both client and server spans.",
+                            "examples": [
+                                "GET",
+                                "POST",
+                                "PUT",
+                                "DELETE",
+                                "PATCH"
+                            ],
+                            "pattern": "^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH)$",
+                            "title": "HTTP Method",
+                            "type": "string",
+                            "is_sensitive": false
+                        },
+                        "http.version": {
+                            "description": "\nThe version of HTTP used for the request.",
+                            "examples": [
+                                "1.0",
+                                "1.1",
+                                "2.0"
+                            ],
+                            "pattern": "^1\\.[01]$|^2\\.0$",
+                            "title": "HTTP Version",
+                            "type": "string",
+                            "is_sensitive": false
+                        },
+                        "http.route": {
+                            "default": null,
+                            "description": "\nThe matched route (path template).\nOnly when span.kind: server.",
+                            "examples": [
+                                "/users/:userID"
+                            ],
+                            "minLength": 1,
+                            "title": "HTTP Route",
+                            "type": "string",
+                            "is_sensitive": false
+                        },
+                        "http.client_ip": {
+                            "default": null,
+                            "description": "\nThe IP address of the original client behind all proxies, if known (discovered from headers such as X-Forwarded-For).",
+                            "examples": [
+                                "192.168.123.132"
+                            ],
+                            "is_sensitive": true,
+                            "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$",
+                            "title": "HTTP Client IP",
+                            "type": "string"
+                        },
+                        "http.useragent": {
+                            "default": null,
+                            "description": "\nThe user agent header received with the request.\nOnly when span.kind: server.",
+                            "examples": [
+                                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                            ],
+                            "is_sensitive": true,
+                            "minLength": 1,
+                            "title": "HTTP User Agent",
+                            "type": "string"
+                        },
+                        "http.request.content_length": {
+                            "default": null,
+                            "description": "\nThe size of the request body.\nThe size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
+                            "examples": [
+                                1234
+                            ],
+                            "exclusiveMinimum": 0,
+                            "is_sensitive": true,
+                            "title": "HTTP Request Content Length",
+                            "type": "integer"
+                        },
+                        "http.response.content_length": {
+                            "default": null,
+                            "description": "\nThe size of the response payload body in bytes.\nThe size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
+                            "examples": [
+                                1234
+                            ],
+                            "exclusiveMinimum": 0,
+                            "is_sensitive": true,
+                            "title": "HTTP Response Content Length",
+                            "type": "integer"
+                        },
+                        "http.request.content_length_uncompressed": {
+                            "default": null,
+                            "description": "\nThe size of the request payload body after transport decoding. Not set if transport encoding not used.",
+                            "examples": [
+                                1234
+                            ],
+                            "exclusiveMinimum": 0,
+                            "is_sensitive": true,
+                            "title": "HTTP Request Content Length Uncompressed",
+                            "type": "integer"
+                        },
+                        "span.kind": {
+                            "title": "Span Kind",
+                            "description": "Span Kind",
+                            "type": "string",
+                            "enum": [
+                                "client",
+                                "server",
+                                "producer",
+                                "consumer",
+                                "internal"
+                            ],
+                            "is_sensitive": false
+                        },
+                        "http.response.content_length_uncompressed": {
+                            "default": null,
+                            "description": "\nThe size of the response payload body after transport decoding. Not set if transport encoding not used.",
+                            "examples": [
+                                1234
+                            ],
+                            "exclusiveMinimum": 0,
+                            "is_sensitive": true,
+                            "title": "HTTP Response Content Length Uncompressed",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "span.kind",
+                        "http.status_code",
+                        "http.url",
+                        "http.method"
+                    ]
+                },
+                "DBTags": {
+                    "title": "HTTP DB Tags",
+                    "description": "HTTP DB Tags",
+                    "properties": {
+                        "_dd.hostname": {
+                            "title": "Hostname",
+                            "description": "Hostname of where the agent is running.",
+                            "type": "string",
+                            "default": null,
+                            "examples": [
+                                "my-hostname"
+                            ],
+                            "minLength": 0,
+                            "is_sensitive": false
+                        },
+                        "db.system": {
+                            "description": "An identifier for the database management system (DBMS) product being used.",
+                            "examples": [
+                                "mysql",
+                                "postgresql"
+                            ],
+                            "type": "string",
+                            "enum": [
+                                "adabas",
+                                "buntdb",
+                                "cache"
+                            ],
+                            "title": "DB System",
+                            "is_sensitive": false
+                        },
+                        "db.connection_string": {
+                            "default": null,
+                            "description": "The connection string used to connect to the database.",
+                            "examples": [
+                                "Server=(localdb)\u000b11.0;Integrated Security=true;",
+                                "postgresql://localhost:5432"
+                            ],
+                            "is_sensitive": true,
+                            "title": "DB Connection String",
+                            "type": "string"
+                        },
+                        "db.user": {
+                            "default": null,
+                            "description": "Username for accessing the database.",
+                            "examples": [
+                                "widget_user"
+                            ],
+                            "title": "DB User",
+                            "type": "string",
+                            "is_sensitive": false
+                        },
+                        "db.name": {
+                            "default": null,
+                            "description": "The name of the database being connected to.",
+                            "examples": [
+                                "customers"
+                            ],
+                            "title": "DB Name",
+                            "type": "string",
+                            "is_sensitive": false
+                        },
+                        "db.statement": {
+                            "default": null,
+                            "description": "The database statement being executed.",
+                            "examples": [
+                                "SELECT * FROM wuser_table', 'SET mykey \"WuValue"
+                            ],
+                            "is_sensitive": true,
+                            "title": "DB Statement",
+                            "type": "string"
+                        },
+                        "db.operation": {
+                            "default": null,
+                            "description": "The name of the operation being executed, e.g. the MongoDB command name such as findAndModify, or the SQL keyword.",
+                            "examples": [
+                                "findAndModify",
+                                "HMSET",
+                                "SELECT"
+                            ],
+                            "title": "DB Operation",
+                            "type": "string",
+                            "is_sensitive": false
+                        },
+                        "db.sql.table": {
+                            "default": null,
+                            "description": "The name of the primary table that the operation is acting upon, including the database name (if applicable).",
+                            "examples": [
+                                "customers"
+                            ],
+                            "title": "DB SQL Table",
+                            "type": "string",
+                            "is_sensitive": false
+                        },
+                        "span.kind": {
+                            "title": "Span Kind",
+                            "description": "Span Kind",
+                            "type": "string",
+                            "enum": [
+                                "client",
+                                "server",
+                                "producer",
+                                "consumer",
+                                "internal"
+                            ],
+                            "is_sensitive": false
+                        },
+                        "db.row_count": {
+                            "default": null,
+                            "description": "\nThe number of rows/results from the query or operation. For caches and other datastores, i.e. Redis, this tag should only set for operations that retrieve stored data,\nsuch as GET operations and queries, excluding SET and other commands not returning data. ",
+                            "examples": [
+                                "customers"
+                            ],
+                            "minimum": 0,
+                            "title": "DB Row Count",
+                            "type": "integer",
+                            "is_sensitive": false
+                        }
+                    },
+                    "required": [
+                        "span.kind",
+                        "db.system"
+                    ]
+                }
+            }
+        },
+        "DBTags": {
+            "title": "HTTP DB Tags",
+            "description": "HTTP DB Tags",
+            "properties": {
+                "_dd.hostname": {
+                    "title": "Hostname",
+                    "description": "Hostname of where the agent is running.",
+                    "type": "string",
+                    "default": null,
+                    "examples": [
+                        "my-hostname"
+                    ],
+                    "minLength": 0,
+                    "is_sensitive": false
+                },
+                "db.system": {
+                    "description": "An identifier for the database management system (DBMS) product being used.",
+                    "examples": [
+                        "mysql",
+                        "postgresql"
+                    ],
+                    "type": "string",
+                    "enum": [
+                        "adabas",
+                        "buntdb",
+                        "cache"
+                    ],
+                    "title": "DB System",
+                    "is_sensitive": false
+                },
+                "db.connection_string": {
+                    "default": null,
+                    "description": "The connection string used to connect to the database.",
+                    "examples": [
+                        "Server=(localdb)\u000b11.0;Integrated Security=true;",
+                        "postgresql://localhost:5432"
+                    ],
+                    "is_sensitive": true,
+                    "title": "DB Connection String",
+                    "type": "string"
+                },
+                "db.user": {
+                    "default": null,
+                    "description": "Username for accessing the database.",
+                    "examples": [
+                        "widget_user"
+                    ],
+                    "title": "DB User",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "db.name": {
+                    "default": null,
+                    "description": "The name of the database being connected to.",
+                    "examples": [
+                        "customers"
+                    ],
+                    "title": "DB Name",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "db.statement": {
+                    "default": null,
+                    "description": "The database statement being executed.",
+                    "examples": [
+                        "SELECT * FROM wuser_table', 'SET mykey \"WuValue"
+                    ],
+                    "is_sensitive": true,
+                    "title": "DB Statement",
+                    "type": "string"
+                },
+                "db.operation": {
+                    "default": null,
+                    "description": "The name of the operation being executed, e.g. the MongoDB command name such as findAndModify, or the SQL keyword.",
+                    "examples": [
+                        "findAndModify",
+                        "HMSET",
+                        "SELECT"
+                    ],
+                    "title": "DB Operation",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "db.sql.table": {
+                    "default": null,
+                    "description": "The name of the primary table that the operation is acting upon, including the database name (if applicable).",
+                    "examples": [
+                        "customers"
+                    ],
+                    "title": "DB SQL Table",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "span.kind": {
+                    "title": "Span Kind",
+                    "description": "Span Kind",
+                    "type": "string",
+                    "enum": [
+                        "client",
+                        "server",
+                        "producer",
+                        "consumer",
+                        "internal"
+                    ],
+                    "is_sensitive": false
+                },
+                "db.row_count": {
+                    "default": null,
+                    "description": "\nThe number of rows/results from the query or operation. For caches and other datastores, i.e. Redis, this tag should only set for operations that retrieve stored data,\nsuch as GET operations and queries, excluding SET and other commands not returning data. ",
+                    "examples": [
+                        "customers"
+                    ],
+                    "minimum": 0,
+                    "title": "DB Row Count",
+                    "type": "integer",
+                    "is_sensitive": false
+                }
+            },
+            "required": [
+                "span.kind",
+                "db.system"
+            ]
+        }
+    }
+}

--- a/semantic-core/cue/gen/schemas/span.json
+++ b/semantic-core/cue/gen/schemas/span.json
@@ -1,0 +1,476 @@
+{
+    "title": "Span",
+    "description": "Span",
+    "type": "object",
+    "properties": {
+        "service": {
+            "description": "The name of the service with which this span is associated",
+            "title": "Service",
+            "type": "string"
+        },
+        "name": {
+            "description": "The operation name of this span",
+            "title": "Name",
+            "type": "string"
+        },
+        "resource": {
+            "description": "The resource name of this span, also sometimes called the endpoint (for web spans)",
+            "title": "Resource",
+            "type": "string"
+        },
+        "traceID": {
+            "description": "The ID of the trace to which this span belongs",
+            "title": "Trace ID",
+            "type": "string"
+        },
+        "spanID": {
+            "description": "The ID of this span",
+            "title": "Span ID",
+            "type": "string"
+        },
+        "parentID": {
+            "default": null,
+            "description": "The ID of this span's parent, or zero if this span has no parent",
+            "title": "Parent ID",
+            "type": "string"
+        },
+        "start": {
+            "description": "The number of nanoseconds between the Unix epoch and the beginning of this span",
+            "title": "Start",
+            "type": "string"
+        },
+        "duration": {
+            "description": "The time length of this span in nanoseconds",
+            "title": "Duration",
+            "type": "string"
+        },
+        "error": {
+            "default": null,
+            "description": "Error is 1 if there is an error associated with this span, or 0 if there is not",
+            "title": "Error",
+            "type": "integer"
+        },
+        "meta": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "default": null,
+            "description": "Meta is a mapping from tag name to tag value for string-valued tags",
+            "title": "Meta",
+            "type": "object"
+        },
+        "metrics": {
+            "additionalProperties": {
+                "type": "number"
+            },
+            "default": null,
+            "description": "Metrics is a mapping from tag name to tag value for numeric-valued tags",
+            "title": "Metrics",
+            "type": "object"
+        },
+        "type": {
+            "default": null,
+            "description": "Represents the type of the service with which this span is associated. Example values: `web`, `db`, `lambda`",
+            "title": "Type",
+            "type": "string"
+        },
+        "meta_struct": {
+            "additionalProperties": {
+                "type": "integer"
+            },
+            "default": null,
+            "description": "Represents a registry of structured \"other\" data used by, e.g., AppSec",
+            "title": "Meta Struct",
+            "type": "object"
+        }
+    },
+    "required": [
+        "service",
+        "name",
+        "resource",
+        "traceID",
+        "spanID",
+        "start",
+        "duration"
+    ],
+    "allOf": [
+        {
+            "if": {
+                "not": {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "web",
+                                "db"
+                            ]
+                        }
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "meta": {
+                        "$ref": "#/$defs/BaseTags"
+                    }
+                }
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "type": {
+                        "const": "web"
+                    }
+                },
+                "required": [
+                    "type"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "meta": {
+                        "$ref": "#/$defs/HTTPTags"
+                    }
+                }
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "type": {
+                        "const": "db"
+                    }
+                },
+                "required": [
+                    "type"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "meta": {
+                        "$ref": "#/$defs/DBTags"
+                    }
+                }
+            }
+        }
+    ],
+    "$defs": {
+        "BaseTags": {
+            "title": "Base Tags",
+            "description": "Base Tags",
+            "properties": {
+                "_dd.hostname": {
+                    "title": "Hostname",
+                    "description": "Hostname of where the agent is running.",
+                    "type": "string",
+                    "default": null,
+                    "examples": [
+                        "my-hostname"
+                    ],
+                    "minLength": 0,
+                    "is_sensitive": false
+                },
+                "span.kind": {
+                    "title": "Span Kind",
+                    "description": "Span Kind",
+                    "type": "string",
+                    "enum": [
+                        "client",
+                        "server",
+                        "producer",
+                        "consumer",
+                        "internal"
+                    ],
+                    "is_sensitive": false
+                }
+            },
+            "required": [
+                "span.kind"
+            ]
+        },
+        "HTTPTags": {
+            "title": "HTTP Meta Tags",
+            "description": "HTTP Meta Tags",
+            "properties": {
+                "_dd.hostname": {
+                    "title": "Hostname",
+                    "description": "Hostname of where the agent is running.",
+                    "type": "string",
+                    "default": null,
+                    "examples": [
+                        "my-hostname"
+                    ],
+                    "minLength": 0,
+                    "is_sensitive": false
+                },
+                "http.status_code": {
+                    "description": "\nThe HTTP response status code.\nWhen span.kind: client the response status code received.\nWhen span.kind: server the response status code sent.\nNote: Although this is an integer, it must be sent as a string.",
+                    "examples": [
+                        "200",
+                        "404",
+                        "500"
+                    ],
+                    "pattern": "^[12345]\\d\\d$",
+                    "title": "HTTP Status Code",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "http.url": {
+                    "description": "\nThe URL of the HTTP request, including the obfuscated query string.",
+                    "examples": [
+                        "https://example.com:443/search?q=datadog"
+                    ],
+                    "is_sensitive": true,
+                    "minLength": 1,
+                    "title": "HTTP URL",
+                    "type": "string"
+                },
+                "http.method": {
+                    "description": "\nThe HTTP method used for the connection. Required for both client and server spans.",
+                    "examples": [
+                        "GET",
+                        "POST",
+                        "PUT",
+                        "DELETE",
+                        "PATCH"
+                    ],
+                    "pattern": "^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH)$",
+                    "title": "HTTP Method",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "http.version": {
+                    "description": "\nThe version of HTTP used for the request.",
+                    "examples": [
+                        "1.0",
+                        "1.1",
+                        "2.0"
+                    ],
+                    "pattern": "^1\\.[01]$|^2\\.0$",
+                    "title": "HTTP Version",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "http.route": {
+                    "default": null,
+                    "description": "\nThe matched route (path template).\nOnly when span.kind: server.",
+                    "examples": [
+                        "/users/:userID"
+                    ],
+                    "minLength": 1,
+                    "title": "HTTP Route",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "http.client_ip": {
+                    "default": null,
+                    "description": "\nThe IP address of the original client behind all proxies, if known (discovered from headers such as X-Forwarded-For).",
+                    "examples": [
+                        "192.168.123.132"
+                    ],
+                    "is_sensitive": true,
+                    "pattern": "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$",
+                    "title": "HTTP Client IP",
+                    "type": "string"
+                },
+                "http.useragent": {
+                    "default": null,
+                    "description": "\nThe user agent header received with the request.\nOnly when span.kind: server.",
+                    "examples": [
+                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                    ],
+                    "is_sensitive": true,
+                    "minLength": 1,
+                    "title": "HTTP User Agent",
+                    "type": "string"
+                },
+                "http.request.content_length": {
+                    "default": null,
+                    "description": "\nThe size of the request body.\nThe size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
+                    "examples": [
+                        1234
+                    ],
+                    "exclusiveMinimum": 0,
+                    "is_sensitive": true,
+                    "title": "HTTP Request Content Length",
+                    "type": "integer"
+                },
+                "http.response.content_length": {
+                    "default": null,
+                    "description": "\nThe size of the response payload body in bytes.\nThe size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header.\nFor requests using transport encoding, this should be compressed size.",
+                    "examples": [
+                        1234
+                    ],
+                    "exclusiveMinimum": 0,
+                    "is_sensitive": true,
+                    "title": "HTTP Response Content Length",
+                    "type": "integer"
+                },
+                "http.request.content_length_uncompressed": {
+                    "default": null,
+                    "description": "\nThe size of the request payload body after transport decoding. Not set if transport encoding not used.",
+                    "examples": [
+                        1234
+                    ],
+                    "exclusiveMinimum": 0,
+                    "is_sensitive": true,
+                    "title": "HTTP Request Content Length Uncompressed",
+                    "type": "integer"
+                },
+                "span.kind": {
+                    "title": "Span Kind",
+                    "description": "Span Kind",
+                    "type": "string",
+                    "enum": [
+                        "client",
+                        "server",
+                        "producer",
+                        "consumer",
+                        "internal"
+                    ],
+                    "is_sensitive": false
+                },
+                "http.response.content_length_uncompressed": {
+                    "default": null,
+                    "description": "\nThe size of the response payload body after transport decoding. Not set if transport encoding not used.",
+                    "examples": [
+                        1234
+                    ],
+                    "exclusiveMinimum": 0,
+                    "is_sensitive": true,
+                    "title": "HTTP Response Content Length Uncompressed",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "span.kind",
+                "http.status_code",
+                "http.url",
+                "http.method"
+            ]
+        },
+        "DBTags": {
+            "title": "HTTP DB Tags",
+            "description": "HTTP DB Tags",
+            "properties": {
+                "_dd.hostname": {
+                    "title": "Hostname",
+                    "description": "Hostname of where the agent is running.",
+                    "type": "string",
+                    "default": null,
+                    "examples": [
+                        "my-hostname"
+                    ],
+                    "minLength": 0,
+                    "is_sensitive": false
+                },
+                "db.system": {
+                    "description": "An identifier for the database management system (DBMS) product being used.",
+                    "examples": [
+                        "mysql",
+                        "postgresql"
+                    ],
+                    "type": "string",
+                    "enum": [
+                        "adabas",
+                        "buntdb",
+                        "cache"
+                    ],
+                    "title": "DB System",
+                    "is_sensitive": false
+                },
+                "db.connection_string": {
+                    "default": null,
+                    "description": "The connection string used to connect to the database.",
+                    "examples": [
+                        "Server=(localdb)\u000b11.0;Integrated Security=true;",
+                        "postgresql://localhost:5432"
+                    ],
+                    "is_sensitive": true,
+                    "title": "DB Connection String",
+                    "type": "string"
+                },
+                "db.user": {
+                    "default": null,
+                    "description": "Username for accessing the database.",
+                    "examples": [
+                        "widget_user"
+                    ],
+                    "title": "DB User",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "db.name": {
+                    "default": null,
+                    "description": "The name of the database being connected to.",
+                    "examples": [
+                        "customers"
+                    ],
+                    "title": "DB Name",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "db.statement": {
+                    "default": null,
+                    "description": "The database statement being executed.",
+                    "examples": [
+                        "SELECT * FROM wuser_table', 'SET mykey \"WuValue"
+                    ],
+                    "is_sensitive": true,
+                    "title": "DB Statement",
+                    "type": "string"
+                },
+                "db.operation": {
+                    "default": null,
+                    "description": "The name of the operation being executed, e.g. the MongoDB command name such as findAndModify, or the SQL keyword.",
+                    "examples": [
+                        "findAndModify",
+                        "HMSET",
+                        "SELECT"
+                    ],
+                    "title": "DB Operation",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "db.sql.table": {
+                    "default": null,
+                    "description": "The name of the primary table that the operation is acting upon, including the database name (if applicable).",
+                    "examples": [
+                        "customers"
+                    ],
+                    "title": "DB SQL Table",
+                    "type": "string",
+                    "is_sensitive": false
+                },
+                "span.kind": {
+                    "title": "Span Kind",
+                    "description": "Span Kind",
+                    "type": "string",
+                    "enum": [
+                        "client",
+                        "server",
+                        "producer",
+                        "consumer",
+                        "internal"
+                    ],
+                    "is_sensitive": false
+                },
+                "db.row_count": {
+                    "default": null,
+                    "description": "\nThe number of rows/results from the query or operation. For caches and other datastores, i.e. Redis, this tag should only set for operations that retrieve stored data,\nsuch as GET operations and queries, excluding SET and other commands not returning data. ",
+                    "examples": [
+                        "customers"
+                    ],
+                    "minimum": 0,
+                    "title": "DB Row Count",
+                    "type": "integer",
+                    "is_sensitive": false
+                }
+            },
+            "required": [
+                "span.kind",
+                "db.system"
+            ]
+        }
+    }
+}

--- a/semantic-core/cue/json_schema_types.cue
+++ b/semantic-core/cue/json_schema_types.cue
@@ -1,0 +1,46 @@
+package schema
+
+// #Property defines a property as defined in JSON Schema: https://json-schema.org/understanding-json-schema/reference/object#properties
+#Property: {
+	title:       string
+	description: string
+	examples?: [...]
+	default?:          _
+	exclusiveMinimum?: number
+	minLength?:        number
+	type:              #Type
+	enum?: [...string]
+	pattern?: string
+	minimum?: number
+
+	if type == "object" {
+		additionalProperties: bool | {type: #Type}
+	}
+
+	if type == "array" {
+		"items": {
+			"$ref"?: string
+			type?:   #Type
+		}
+	}
+
+	// custom stuff
+	is_sensitive: bool | *false
+}
+
+// #JSONSchema defines a schema from JSON Schema: https://json-schema.org/understanding-json-schema/reference
+#JSONSchema: {
+	title:       string
+	description: string
+	properties:  #Properties
+	type?:       #Type
+	required?: [...string]
+	$defs?: [string]: #JSONSchema
+	allOf?: [...]
+}
+
+// Properties defines a map of properties
+#Properties: [string]: #Property
+
+// Type represents all the available types in JSON Schema
+#Type: "string" | "integer" | "number" | "object" | "boolean" | "array"

--- a/semantic-core/cue/schema_agent_payload.cue
+++ b/semantic-core/cue/schema_agent_payload.cue
@@ -1,0 +1,195 @@
+package schema
+
+// AgentPayload represents the JSON Schema to validate Agent payloads.
+AgentPayload: #JSONSchema & {
+	"title":     "AgentPayload"
+	description: "Represents the generic semantics for the agent payload, structurally defined here: https://github.com/DataDog/datadog-agent/blob/main/pkg/proto/datadog/trace/agent_payload.proto"
+	"type":      "object"
+	properties: {
+		hostName: Fields.Common["_dd.hostname"]
+		"env": {
+			"default":     null
+			"description": "Specifies the 'env' set in the agent's configuration."
+			"minLength":   1
+			"title":       "Env"
+			"type":        "string"
+		}
+		"tags": {
+			"additionalProperties": {
+				"type": "string"
+			}
+			"default":     null
+			"description": "Tags specifies tags common in all `tracerPayloads`"
+			"title":       "Tags"
+			"type":        "object"
+		}
+		"agentVersion": {
+			"description": "Specifies version of the agent"
+			"minLength":   1
+			"title":       "Agent Version"
+			"type":        "string"
+		}
+		"targetTPS": {
+			"description":      "Holds `TargetTPS` value in AgentConfig"
+			"exclusiveMinimum": 0.0
+			"title":            "Target TPS"
+			"type":             "number"
+		}
+		"errorTPS": {
+			"description":      "Holds `ErrorTPS` value in AgentConfig"
+			"exclusiveMinimum": 0.0
+			"title":            "Error TPS"
+			"type":             "number"
+		}
+		"rareSamplerEnabled": {
+			"default":     null
+			"description": "Holds `RareSamplerEnabled` value in AgentConfig"
+			"title":       "Rare Sampler Flag"
+			"type":        "boolean"
+		}
+		tracerPayloads: {
+			"title":       "Tracer Payloads"
+			"description": "Specifies the list of the payloads received from tracers"
+			"items": {
+				"$ref": "#/$defs/TracerPayload"
+			}
+			"type": "array"
+		}
+	}
+	"required": [
+		"agentVersion",
+		"targetTPS",
+		"errorTPS",
+		"tracerPayloads",
+	]
+	$defs: {
+		"TracerPayload": TracerPayload
+		"TraceChunk":    TraceChunk
+		"Span":          Span
+		Span.$defs
+	}
+}
+
+TracerPayload: {
+	"title":     "TracerPayload"
+	description: "Tracer Payload"
+	"type":      "object"
+	"properties": {
+		"containerID": {
+			"default":     null
+			"description": "Specifies the ID of the container where the tracer is running on"
+			"title":       "Container ID"
+			"type":        "string"
+		}
+		"languageName": {
+			"description": "Specifies the language of the tracer"
+			// "pattern":     "^(golang|python|php|ruby|jvm|dotnet|js)$"
+			"title": "Language Name"
+			"type":  "string"
+			enum: ["go", "python", "php", "ruby", "jvm", "dotnet", "js"]
+		}
+		"languageVersion": {
+			"description": "Specifies the language version of the tracer"
+			"title":       "Language Version"
+			"type":        "string"
+		}
+		"tracerVersion": {
+			"description": "Specifies the version of the tracer"
+			"title":       "Tracer Version"
+			"type":        "string"
+		}
+		"runtimeID": {
+			"default":     null
+			"description": "Specifies V4 UUID representation of a tracer session"
+			"title":       "Runtime ID"
+			"type":        "string"
+		}
+		"chunks": {
+			"description": "Specifies the list of containing trace chunks"
+			"items": {
+				"$ref": "#/$defs/TraceChunk"
+			}
+			"title": "Trace Chunks"
+			"type":  "array"
+		}
+		"tags": {
+			"additionalProperties": {
+				"type": "string"
+			}
+			"default":     null
+			"description": "Specifies the list of tags common in all Trace Chunks"
+			"title":       "Trace Tags"
+			"type":        "object"
+		}
+		"env": {
+			"description": "Specifies the `env` tag that is set in the tracer configuration"
+			"title":       "Env"
+			"type":        "string"
+		}
+		"hostname": {
+			"default":     null
+			"description": "Specifies the hostname where the tracer is running"
+			"title":       "Hostname"
+			"type":        "string"
+		}
+		"appVersion": {
+			"description": "Specifies the `version` tag that set in the tracer configuration"
+			"title":       "App Version"
+			"type":        "string"
+		}
+	}
+	"required": [
+		"languageName",
+		"languageVersion",
+		"tracerVersion",
+		"chunks",
+		"env",
+		"appVersion",
+	]
+}
+
+TraceChunk: {
+	"title":     "TraceChunk"
+	description: "Trace Chunk"
+	"type":      "object"
+	"properties": {
+		"priority": {
+			"description": "Specifies the sampling priority of the trace"
+			"title":       "Priority"
+			"type":        "integer"
+		}
+		"origin": {
+			"default":     null
+			"description": "Specifies the origin product (`lambda`, `rum`, etc.) of the trace"
+			"title":       "Origin"
+			"type":        "string"
+		}
+		"spans": {
+			"description": "Specifies the list of containing spans"
+			"items": {
+				"$ref": "#/$defs/Span"
+			}
+			"title": "Spans"
+			"type":  "array"
+		}
+		"tags": {
+			"additionalProperties": {
+				"type": "string"
+			}
+			"default":     null
+			"description": "Specifies the list of tags common in all Spans"
+			"title":       "Tags"
+			"type":        "object"
+		}
+		"droppedTrace": {
+			"default":     null
+			"description": "Specifies whether the trace was dropped by samplers or not"
+			"title":       "Dropped Trace"
+			"type":        "boolean"
+		}
+	}
+	"required": [
+		"priority",
+		"spans",
+	]
+}

--- a/semantic-core/cue/schema_span.cue
+++ b/semantic-core/cue/schema_span.cue
@@ -1,0 +1,167 @@
+package schema
+
+Span: {
+	"title":     "Span"
+	description: "Span"
+	"type":      "object"
+	"properties": {
+		"service": {
+			"description": "The name of the service with which this span is associated"
+			"title":       "Service"
+			"type":        "string"
+		}
+		"name": {
+			"description": "The operation name of this span"
+			"title":       "Name"
+			"type":        "string"
+		}
+		"resource": {
+			"description": "The resource name of this span, also sometimes called the endpoint (for web spans)"
+			"title":       "Resource"
+			"type":        "string"
+		}
+		"traceID": {
+			"description": "The ID of the trace to which this span belongs"
+			"title":       "Trace ID"
+			// "type":        "integer"
+			"type": "string"
+		}
+		"spanID": {
+			"description": "The ID of this span"
+			"title":       "Span ID"
+			// "type":        "integer"
+			"type": "string"
+		}
+		"parentID": {
+			"default":     null
+			"description": "The ID of this span's parent, or zero if this span has no parent"
+			"title":       "Parent ID"
+			// "type":        "integer"
+			"type": "string"
+		}
+		"start": {
+			"description": "The number of nanoseconds between the Unix epoch and the beginning of this span"
+			"title":       "Start"
+			// "type":        "integer"
+			"type": "string"
+		}
+		"duration": {
+			"description": "The time length of this span in nanoseconds"
+			"title":       "Duration"
+			// "type":        "integer"
+			"type": "string"
+		}
+		"error": {
+			"default":     null
+			"description": "Error is 1 if there is an error associated with this span, or 0 if there is not"
+			"title":       "Error"
+			"type":        "integer"
+		}
+		"meta": {
+			"additionalProperties": {
+				"type": "string"
+			}
+			"default":     null
+			"description": "Meta is a mapping from tag name to tag value for string-valued tags"
+			"title":       "Meta"
+			"type":        "object"
+		}
+		"metrics": {
+			"additionalProperties": {
+				"type": "number"
+			}
+			"default":     null
+			"description": "Metrics is a mapping from tag name to tag value for numeric-valued tags"
+			"title":       "Metrics"
+			"type":        "object"
+		}
+		"type": {
+			"default":     null
+			"description": "Represents the type of the service with which this span is associated. Example values: `web`, `db`, `lambda`"
+			"title":       "Type"
+			"type":        "string"
+		}
+		"meta_struct": {
+			"additionalProperties": {
+				"type": "integer"
+			}
+			"default":     null
+			"description": "Represents a registry of structured \"other\" data used by, e.g., AppSec"
+			"title":       "Meta Struct"
+			"type":        "object"
+		}
+	}
+	"required": [
+		"service",
+		"name",
+		"resource",
+		"traceID",
+		"spanID",
+		"start",
+		"duration",
+	]
+	"allOf": [
+		{
+			if: not: properties: type: enum: ["web", "db"]
+			then: properties: meta: $ref: "#/$defs/BaseTags"
+		},
+		{
+			if: {
+				properties: type: const: "web"
+				required: ["type"]
+			}
+			then: properties: meta: $ref: "#/$defs/HTTPTags"
+		},
+		{
+			if: {
+				properties: type: const: "db"
+				required: ["type"]
+			}
+			then: properties: meta: $ref: "#/$defs/DBTags"
+		},
+	]
+	$defs: {
+		"BaseTags": BaseTags
+		"HTTPTags": HTTPTags
+		"DBTags":   DBTags
+	}
+}
+
+BaseTags: {
+	title:       "Base Tags"
+	description: "Base Tags"
+	properties: {
+		Fields.Common
+	}
+	required: [
+		// "_dd.hostname",
+		"span.kind",
+	]
+}
+
+HTTPTags: {
+	title:       "HTTP Meta Tags"
+	description: "HTTP Meta Tags"
+	properties: {
+		Fields.Common
+		Fields.HTTP
+	}
+	required: BaseTags.required + [
+		"http.status_code",
+		"http.url",
+		"http.method",
+		// "http.version",
+	]
+}
+
+DBTags: {
+	title:       "HTTP DB Tags"
+	description: "HTTP DB Tags"
+	properties: {
+		Fields.Common
+		Fields.DB
+	}
+	required: BaseTags.required + [
+		"db.system",
+	]
+}


### PR DESCRIPTION
This PR illustrates an alternative using Cue to generate the JSON Schema files instead of Pydantic.

It generates the following 2 schemas:

- `agent_payload.json`
- `span.json`

The `span.json` schema contains the logic of the existing `intake_resolved_*_span.json` schemas using the `if/then/else` JSON Schema feature: https://json-schema.org/understanding-json-schema/reference/conditionals#if-then-else

It also contains the changes made in https://github.com/DataDog/schema/pull/39/files 