### PR TITLE
SMTC-54: Add support for "owners" in the semantic model

### DIFF
--- a/semantic-core/generation/gen_semantic_defs.py
+++ b/semantic-core/generation/gen_semantic_defs.py
@@ -6,13 +6,12 @@ import os
 import re
 from typing import NamedTuple
 
-from semantic_model.payloads import IntakeResolvedHttpSpan
-from semantic_model.payloads import IntakeResolvedDbSpan
-from semantic_model.payloads import IntakeResolvedSpan
 from semantic_model.payloads import AgentPayload
-
+from semantic_model.payloads import IntakeResolvedDbSpan
+from semantic_model.payloads import IntakeResolvedHttpSpan
+from semantic_model.payloads import IntakeResolvedSpan
+from semantic_model.registry import OwnersRegistry
 from semantic_model.registry import PropertiesRegistry
-
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -59,16 +58,19 @@ def main():
         logger.info(f"Latest version: {latest_version_info}")
         logger.info(f"New version: {new_version_info}")
 
+        # TODO: [fpaulo] clean this up to clearly separate nodes from registries
+
         try:
-            payload_types = [
+            json_schema_types = [
                 IntakeResolvedSpan,
                 IntakeResolvedHttpSpan,
                 IntakeResolvedDbSpan,
                 AgentPayload,
                 PropertiesRegistry,
+                OwnersRegistry,
             ]
 
-            for pt in payload_types:
+            for pt in json_schema_types:
                 generate_schema(payload_type=pt, version_info=new_version_info)
 
             logger.info(f"Schema successfully generated for version: {new_version_info}")

--- a/semantic-core/generation/semantic_model/registry/__init__.py
+++ b/semantic-core/generation/semantic_model/registry/__init__.py
@@ -1,3 +1,4 @@
 from .properties.properties_registry import PropertiesRegistry
+from .owners.owners_registry import OwnersRegistry
 
-__slots__ = ["PropertiesRegistry"]
+__slots__ = ["PropertiesRegistry", "OwnersRegistry"]

--- a/semantic-core/generation/semantic_model/registry/owners/owners_registry.py
+++ b/semantic-core/generation/semantic_model/registry/owners/owners_registry.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+from .trust_and_safety import TrustAndSafety
+
+
+class OwnersRegistry(BaseModel):
+    """
+    Represents the registry of all Semantic Owners, i.e. the owners that maintain Semantic Properties.
+    """
+
+    trust_and_safety: TrustAndSafety

--- a/semantic-core/generation/semantic_model/registry/owners/trust_and_safety.py
+++ b/semantic-core/generation/semantic_model/registry/owners/trust_and_safety.py
@@ -1,0 +1,8 @@
+from .util import owner
+
+TrustAndSafety = owner(
+    id="trust_and_safety",
+    team="Trust and Safety",
+    description="This is the team responsible for the Trust and Safety of our customers.",
+    contacts=[],
+)

--- a/semantic-core/generation/semantic_model/registry/owners/util.py
+++ b/semantic-core/generation/semantic_model/registry/owners/util.py
@@ -1,0 +1,16 @@
+from typing import Annotated
+
+from pydantic import Field
+
+
+def owner(id: str, team: str, description: str, contacts: list[str]):
+    json_schema_extra = {
+        "id": id,
+        "team": team,
+        "contacts": contacts,
+    }
+
+    return Annotated[
+        str,
+        Field(description=description, json_schema_extra=json_schema_extra),
+    ]


### PR DESCRIPTION
Adding in the owners registry.

generate draft produced:
```
{
  "description": "Represents the registry of all Semantic Owners, i.e. the owners that maintain Semantic Properties.",
  "properties": {
    "trust_and_safety": {
      "contacts": [],
      "description": "This is the team responsible for the Trust and Safety of our customers.",
      "id": "trust_and_safety",
      "team": "Trust and Safety",
      "title": "Trust And Safety",
      "type": "string"
    }
  },
  "required": [
    "trust_and_safety"
  ],
  "title": "OwnersRegistry",
  "type": "object"
}
```