### PR TITLE
SMTC-55: Add support for "aspects" in the semantic model

### DIFF
--- a/semantic-core/generation/gen_semantic_defs.py
+++ b/semantic-core/generation/gen_semantic_defs.py
@@ -10,6 +10,7 @@ from semantic_model.payloads import AgentPayload
 from semantic_model.payloads import IntakeResolvedDbSpan
 from semantic_model.payloads import IntakeResolvedHttpSpan
 from semantic_model.payloads import IntakeResolvedSpan
+from semantic_model.registry import AspectsRegistry
 from semantic_model.registry import OwnersRegistry
 from semantic_model.registry import PropertiesRegistry
 
@@ -68,6 +69,7 @@ def main():
                 AgentPayload,
                 PropertiesRegistry,
                 OwnersRegistry,
+                AspectsRegistry,
             ]
 
             for pt in json_schema_types:

--- a/semantic-core/generation/semantic_model/registry/__init__.py
+++ b/semantic-core/generation/semantic_model/registry/__init__.py
@@ -1,4 +1,5 @@
 from .properties.properties_registry import PropertiesRegistry
 from .owners.owners_registry import OwnersRegistry
+from .aspects.aspects_registry import AspectsRegistry
 
-__slots__ = ["PropertiesRegistry", "OwnersRegistry"]
+__slots__ = ["PropertiesRegistry", "OwnersRegistry", "AspectsRegistry"]

--- a/semantic-core/generation/semantic_model/registry/aspects/aspects_registry.py
+++ b/semantic-core/generation/semantic_model/registry/aspects/aspects_registry.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+from .infosec import InfoSec
+
+
+class AspectsRegistry(BaseModel):
+    """
+    Represents the registry of all Semantic Aspects, i.e. the groups of properties that are related to each other and
+    are curated by one owner.
+    """
+
+    infosec: InfoSec

--- a/semantic-core/generation/semantic_model/registry/aspects/infosec.py
+++ b/semantic-core/generation/semantic_model/registry/aspects/infosec.py
@@ -1,0 +1,7 @@
+from .util import aspect
+
+InfoSec = aspect(
+    id="infosec",
+    owner="trust_and_safety",
+    description="This aspect relates to infosec concerns",
+)

--- a/semantic-core/generation/semantic_model/registry/aspects/util.py
+++ b/semantic-core/generation/semantic_model/registry/aspects/util.py
@@ -1,0 +1,15 @@
+from typing import Annotated
+
+from pydantic import Field
+
+
+def aspect(id: str, owner: str, description: str):
+    json_schema_extra = {
+        "id": id,
+        "owner": owner,
+    }
+
+    return Annotated[
+        str,
+        Field(description=description, json_schema_extra=json_schema_extra),
+    ]


### PR DESCRIPTION
Adding in the owners registry.

generate draft produced:
```
{
  "description": "Represents the registry of all Semantic Aspects, i.e. the groups of properties that are related to each other and\nare curated by one owner.",
  "properties": {
    "infosec": {
      "description": "This aspect relates to infosec concerns",
      "id": "infosec",
      "owner": "trust_and_safety",
      "title": "Infosec",
      "type": "string"
    }
  },
  "required": [
    "infosec"
  ],
  "title": "AspectsRegistry",
  "type": "object"
}
```