### PR TITLE
SMTC-56: Adding support for "signals".

### DIFF
--- a/semantic-core/generation/gen_semantic_defs.py
+++ b/semantic-core/generation/gen_semantic_defs.py
@@ -13,6 +13,7 @@ from semantic_model.payloads import IntakeResolvedSpan
 from semantic_model.registry import AspectsRegistry
 from semantic_model.registry import OwnersRegistry
 from semantic_model.registry import PropertiesRegistry
+from semantic_model.registry import SignalsRegistry
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -70,6 +71,7 @@ def main():
                 PropertiesRegistry,
                 OwnersRegistry,
                 AspectsRegistry,
+                SignalsRegistry,
             ]
 
             for pt in json_schema_types:

--- a/semantic-core/generation/gen_semantic_defs.py
+++ b/semantic-core/generation/gen_semantic_defs.py
@@ -10,6 +10,7 @@ from semantic_model.payloads import AgentPayload
 from semantic_model.payloads import IntakeResolvedDbSpan
 from semantic_model.payloads import IntakeResolvedHttpSpan
 from semantic_model.payloads import IntakeResolvedSpan
+from semantic_model.registry import AspectsRegistry
 from semantic_model.registry import OwnersRegistry
 from semantic_model.registry import PropertiesRegistry
 
@@ -68,6 +69,7 @@ def main():
                 AgentPayload,
                 PropertiesRegistry,
                 OwnersRegistry,
+                AspectsRegistry,
             ]
 
             for pt in json_schema_types:

--- a/semantic-core/generation/semantic_model/registry/__init__.py
+++ b/semantic-core/generation/semantic_model/registry/__init__.py
@@ -1,5 +1,6 @@
 from .properties.properties_registry import PropertiesRegistry
 from .owners.owners_registry import OwnersRegistry
 from .aspects.aspects_registry import AspectsRegistry
+from .signals.signals_registry import SignalsRegistry
 
-__slots__ = ["PropertiesRegistry", "OwnersRegistry", "AspectsRegistry"]
+__slots__ = ["PropertiesRegistry", "OwnersRegistry", "AspectsRegistry", "SignalsRegistry"]

--- a/semantic-core/generation/semantic_model/registry/__init__.py
+++ b/semantic-core/generation/semantic_model/registry/__init__.py
@@ -1,4 +1,5 @@
 from .properties.properties_registry import PropertiesRegistry
 from .owners.owners_registry import OwnersRegistry
+from .aspects.aspects_registry import AspectsRegistry
 
-__slots__ = ["PropertiesRegistry", "OwnersRegistry"]
+__slots__ = ["PropertiesRegistry", "OwnersRegistry", "AspectsRegistry"]

--- a/semantic-core/generation/semantic_model/registry/aspects/aspects_registry.py
+++ b/semantic-core/generation/semantic_model/registry/aspects/aspects_registry.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+from .infosec import InfoSec
+
+
+class AspectsRegistry(BaseModel):
+    """
+    Represents the registry of all Semantic Aspects, i.e. the groups of properties that are related to each other and
+    are curated by one owner.
+    """
+
+    infosec: InfoSec

--- a/semantic-core/generation/semantic_model/registry/aspects/infosec.py
+++ b/semantic-core/generation/semantic_model/registry/aspects/infosec.py
@@ -1,0 +1,7 @@
+from .util import aspect
+
+InfoSec = aspect(
+    id="infosec",
+    owner="trust_and_safety",
+    description="This aspect relates to infosec concerns",
+)

--- a/semantic-core/generation/semantic_model/registry/aspects/util.py
+++ b/semantic-core/generation/semantic_model/registry/aspects/util.py
@@ -1,0 +1,15 @@
+from typing import Annotated
+
+from pydantic import Field
+
+
+def aspect(id: str, owner: str, description: str):
+    json_schema_extra = {
+        "id": id,
+        "owner": owner,
+    }
+
+    return Annotated[
+        str,
+        Field(description=description, json_schema_extra=json_schema_extra),
+    ]

--- a/semantic-core/generation/semantic_model/registry/signals/remove_query_string.py
+++ b/semantic-core/generation/semantic_model/registry/signals/remove_query_string.py
@@ -1,0 +1,9 @@
+from .util import signal
+
+RemoveQueryString = signal(
+    signal_type=bool,
+    description="""
+    True if the agent that sent a payload containing an http utl is configured to remove the query string from the url before sending it to the backend.
+    See: https://docs.datadoghq.com/tracing/configure_data_security/?tab=http
+    """,
+)

--- a/semantic-core/generation/semantic_model/registry/signals/remove_query_string.py
+++ b/semantic-core/generation/semantic_model/registry/signals/remove_query_string.py
@@ -3,7 +3,7 @@ from .util import signal
 RemoveQueryString = signal(
     signal_type=bool,
     description="""
-    True if the agent that sent a payload containing an http utl is configured to remove the query string from the url before sending it to the backend.
+    True if the agent that sent a payload containing an http url is configured to remove the query string from the url before sending it to the backend.
     See: https://docs.datadoghq.com/tracing/configure_data_security/?tab=http
     """,
 )

--- a/semantic-core/generation/semantic_model/registry/signals/signals_registry.py
+++ b/semantic-core/generation/semantic_model/registry/signals/signals_registry.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+from .remove_query_string import RemoveQueryString
+
+
+class SignalsRegistry(BaseModel):
+    """
+    Represents the registry of all signals that can be used to define complex validations.
+    """
+
+    remove_query_string: RemoveQueryString

--- a/semantic-core/generation/semantic_model/registry/signals/util.py
+++ b/semantic-core/generation/semantic_model/registry/signals/util.py
@@ -1,0 +1,22 @@
+import textwrap
+from typing import Annotated
+from typing import TypeVar, Type
+
+from pydantic import Field
+
+T = TypeVar("T")
+
+
+def signal(signal_type: Type[T], description: str):
+    """
+    This function produces a "signal", represented as an extension of a base type (ex: int) with additional information.
+    Signals are meant to be used as part of the definition of complex validations.
+
+    :param signal_type: The type of the signal.
+    :param description: The description of the signal.
+    """
+
+    return Annotated[
+        signal_type,
+        Field(description=textwrap.dedent(description).lstrip()),
+    ]


### PR DESCRIPTION
```
{
  "description": "Represents the registry of all signals that can be used to define complex validations.",
  "properties": {
    "remove_query_string": {
      "description": "True if the agent that sent a payload containing an http utl is configured to remove the query string from the url before sending it to the backend.\nSee: https://docs.datadoghq.com/tracing/configure_data_security/?tab=http\n",
      "title": "Remove Query String",
      "type": "boolean"
    }
  },
  "required": [
    "remove_query_string"
  ],
  "title": "SignalsRegistry",
  "type": "object"
}
```