### PR TITLE
Update public v3 schema

### DIFF
--- a/service-catalog/entity.schema.json
+++ b/service-catalog/entity.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/DataDog/schema/tree/main/service-catalog/entity.schema.json",
+  "oneOf": [
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "service"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/service.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "queue"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/queue.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "datastore"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/datastore.schema.json"
+        }
+      ]
+    },    
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "system"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/system.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "ui"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/ui.schema.json"
+        }
+      ]
+    }
+  ]
+}

--- a/service-catalog/service.schema.json
+++ b/service-catalog/service.schema.json
@@ -1,0 +1,64 @@
+{
+  "$id": "https://github.com/DataDog/schema/tree/main/service-catalog/version.schema.json",
+  "$schema": "https://raw.githubusercontent.com/DataDog/schema/main/.version/schema.json#",
+  "title": "All Service Definition Versions",
+  "type": "object",
+  "oneOf": [
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "v1"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v1/schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "v2"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2/schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "v2.1"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.1/schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "v2.2"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.2/schema.json"
+        }
+      ]
+    }
+  ]
+}

--- a/service-catalog/v3/datadog_code.schema.json
+++ b/service-catalog/v3/datadog_code.schema.json
@@ -1,14 +1,23 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/datadog_code.schema.json",
-  "type": "object",
+  "type": "array",
   "additionalProperties": false,
   "properties": {
-    "paths": {
-      "type": "array",
-      "description": "The paths (glob) to the source code of the service",
-      "items": {
-        "type": "string"
+    "items": {
+      "properties": {
+        "repositoryURL": {
+          "description": "The repository path of the source code of the entity",
+          "type": "string",
+          "pattern": "url"
+        },
+        "paths": {
+          "type": "array",
+          "description": "The paths (glob) to the source code of the service",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     }
   }

--- a/service-catalog/v3/datastore.schema.json
+++ b/service-catalog/v3/datastore.schema.json
@@ -5,7 +5,7 @@
   "examples": [],
   "allOf": [
     {
-      "$ref": "entity.schema.json#"
+      "$ref": "entity.schema.json"
     },
     {
       "type": "object",
@@ -51,16 +51,16 @@
           }
         },
         "integrations": {
-          "$ref": "integration.schema.json#"
+          "$ref": "integration.schema.json"
         },
         "datadog": {
           "type": "object",
           "description": "Datadog product integrations for the datastore entity",
           "additionalProperties": false,
           "properties": {
-            "performanceData": {"$ref": "datadog_performance.schema.json#"},
-            "events": {"$ref": "datadog_events.schema.json#"},
-            "logs": {"$ref": "datadog_logs.schema.json#"}
+            "performanceData": {"$ref": "datadog_performance.schema.json"},
+            "events": {"$ref": "datadog_events.schema.json"},
+            "logs": {"$ref": "datadog_logs.schema.json"}
           }
         }
       }

--- a/service-catalog/v3/integration.schema.json
+++ b/service-catalog/v3/integration.schema.json
@@ -5,7 +5,7 @@
   "additionalProperties": false,
   "type": "object",
   "properties": {
-    "pagerduty": {"$ref": "integration_pagerduty.schema.json#"},
-    "opsgenie": {"$ref": "integration_opsgenie.schema.json#"}
+    "pagerduty": {"$ref": "integration_pagerduty.schema.json"},
+    "opsgenie": {"$ref": "integration_opsgenie.schema.json"}
   }
 }

--- a/service-catalog/v3/queue.schema.json
+++ b/service-catalog/v3/queue.schema.json
@@ -5,7 +5,7 @@
   "examples": [],
   "allOf": [
     {
-      "$ref": "entity.schema.json#"
+      "$ref": "entity.schema.json"
     },
     {
       "type": "object",
@@ -51,16 +51,16 @@
           }
         },
         "integrations": {
-          "$ref": "integration.schema.json#"
+          "$ref": "integration.schema.json"
         },
         "datadog": {
           "type": "object",
           "description": "Datadog product integrations for the datastore entity",
           "additionalProperties": false,
           "properties": {
-            "performanceData": {"$ref": "datadog_performance.schema.json#"},
-            "events": {"$ref": "datadog_events.schema.json#"},
-            "logs": {"$ref": "datadog_logs.schema.json#"}
+            "performanceData": {"$ref": "datadog_performance.schema.json"},
+            "events": {"$ref": "datadog_events.schema.json"},
+            "logs": {"$ref": "datadog_logs.schema.json"}
           }
         }
       }

--- a/service-catalog/v3/service.schema.json
+++ b/service-catalog/v3/service.schema.json
@@ -72,18 +72,18 @@
           }
         },
         "integrations": {
-          "$ref": "integration.schema.json#"
+          "$ref": "integration.schema.json"
         },
         "datadog": {
           "type": "object",
           "description": "Datadog product integrations for the service entity",
           "additionalProperties": false,
           "properties": {
-            "performanceData": {"$ref": "datadog_performance.schema.json#"},
-            "pipelines": {"$ref": "datadog_pipelines.schema.json#"},
-            "events": {"$ref": "datadog_events.schema.json#"},
-            "logs": {"$ref": "datadog_logs.schema.json#"},
-            "code": {"$ref": "datadog_code.schema.json#"}
+            "performanceData": {"$ref": "datadog_performance.schema.json"},
+            "pipelines": {"$ref": "datadog_pipelines.schema.json"},
+            "events": {"$ref": "datadog_events.schema.json"},
+            "logs": {"$ref": "datadog_logs.schema.json"},
+            "code": {"$ref": "datadog_code.schema.json"}
           }
         }
       }

--- a/service-catalog/v3/system.schema.json
+++ b/service-catalog/v3/system.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/application.schema.json",
-  "description": "[Deprecated - replaced by kind:system] Schema for application entities",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/system.schema.json",
+  "description": "Schema for system entities",
   "allOf": [
     {
       "$ref": "entity.schema.json"
@@ -14,7 +14,7 @@
           "enum": ["v3"]
         },
         "kind": {
-          "enum": ["application"]
+          "enum": ["system"]
         },
         "spec": {
           "type": "object",
@@ -40,7 +40,7 @@
               "minLength": 1
             },
             "components": {
-              "description": "A list of components belongs to the application.",
+              "description": "A list of components belongs to the system.",
               "examples": [
                 "service:myapp",
                 "queue:myqueue",

--- a/service-catalog/v3/ui.schema.json
+++ b/service-catalog/v3/ui.schema.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/application.schema.json",
-  "description": "[Deprecated - replaced by kind:system] Schema for application entities",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/ui.schema.json",
+  "description": "Schema for User Interface (UI) entities",
+  "examples": [],
   "allOf": [
     {
       "$ref": "entity.schema.json"
@@ -14,7 +15,13 @@
           "enum": ["v3"]
         },
         "kind": {
-          "enum": ["application"]
+          "enum": ["ui"]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "extensions": {
+          "type": "object"
         },
         "spec": {
           "type": "object",
@@ -32,20 +39,19 @@
             },
             "tier": {
               "type": "string",
-              "description": "An entity reference to the owner of the component.",
-              "examples": [
-                "artist-relations-team",
-                "user:john.johnson"
-              ],
+              "description": "The importance of the component",
+              "examples": ["1", "High"],
               "minLength": 1
             },
-            "components": {
-              "description": "A list of components belongs to the application.",
+            "type": {
+              "description": "The type of user interface",
+              "examples": ["web", "mobile", "desktop", "cli"],
+              "type": "string"
+            },
+            "dependsOn": {
+              "description": "The dependencies of the UI",
               "examples": [
-                "service:myapp",
-                "queue:myqueue",
-                "datastore:mydatastore",
-                "library:mylibrary"
+                "service:backendService"
               ],
               "type": "array",
               "items": {
@@ -54,24 +60,19 @@
             }
           }
         },
-        "metadata": {
-          "type": "object"
-        },
-        "extensions": {
-          "type": "object"
-        },
         "integrations": {
           "$ref": "integration.schema.json"
         },
         "datadog": {
           "type": "object",
-          "description": "Datadog product integrations for the service entity",
+          "description": "Datadog product integrations for the UI entity",
           "additionalProperties": false,
           "properties": {
             "performanceData": {"$ref": "datadog_performance.schema.json"},
             "pipelines": {"$ref": "datadog_pipelines.schema.json"},
             "events": {"$ref": "datadog_events.schema.json"},
-            "logs": {"$ref": "datadog_logs.schema.json"}
+            "logs": {"$ref": "datadog_logs.schema.json"},
+            "code": {"$ref": "datadog_code.schema.json"}
           }
         }
       }


### PR DESCRIPTION
Few changes to v3 schema
1. deprecate `kind:application`, replace by `kind:system`
2. add the following new entity kinds: 
   - system (replacing application
   - ui (represents a user interface component, such as web, mobile, desktop client, etc..) 
3. misc fixes to streamline references. 
4. added a new top level schema called "service.schema.json" which is a duplicate of "version.schema.json". Will remove "version.schema.json" once we update the reference in the schema registry. 