### PR TITLE
[SER-601] Add v2 IDE completion/validation to entity.schema.json

### DIFF
--- a/service-catalog/entity.schema.json
+++ b/service-catalog/entity.schema.json
@@ -1,8 +1,50 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/entity.schema.json",
-  "title": "Software Catalog Definition Versions [v3]",
+  "title": "Software Catalog Definition Versions [v2, v3]",
   "oneOf": [
+    {
+      "allOf": [
+        {
+          "properties": {
+            "schema-version": {
+              "const": "v2"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2/schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "schema-version": {
+              "const": "v2.1"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.1/schema.json"
+        }
+      ]
+    },    
+    {
+      "allOf": [
+        {
+          "properties": {
+            "schema-version": {
+              "const": "v2.2"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.2/schema.json"
+        }
+      ]
+    },
     {
       "allOf": [
         {

--- a/service-catalog/entity.schema.json
+++ b/service-catalog/entity.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/entity.schema.json",
-  "title": "Software Catalog Definition Versions [v2, v3]",
+  "title": "Software Catalog Definition Versions [v2, v2.1, v2.2, v3]",
   "oneOf": [
     {
       "allOf": [

--- a/service-catalog/service.schema.json
+++ b/service-catalog/service.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/service.schema.json",
-  "title": "Service Definition Versions [v1, v2, v2.1, v2.2, v3]",
+  "title": "Service Definition Versions [v1, v2, v2.1, v2.2]",
   "oneOf": [
     {
       "allOf": [
@@ -56,23 +56,6 @@
         },
         {
           "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.2/schema.json"
-        }
-      ]
-    },
-    {
-      "allOf": [
-        {
-          "properties": {
-            "apiVersion": {
-              "const": "v3"
-            }, 
-            "kind": {
-              "const": "service"
-            }
-          }
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/service.schema.json"
         }
       ]
     }

--- a/service-catalog/service.schema.json
+++ b/service-catalog/service.schema.json
@@ -58,6 +58,74 @@
           "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.2/schema.json"
         }
       ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "service"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/service.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "queue"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/queue.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "datastore"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/datastore.schema.json"
+        }
+      ]
+    },    
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "system"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/system.schema.json"
+        }
+      ]
     }
   ]
 }

--- a/service-catalog/service.schema.json
+++ b/service-catalog/service.schema.json
@@ -75,57 +75,6 @@
           "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/service.schema.json"
         }
       ]
-    },
-    {
-      "allOf": [
-        {
-          "properties": {
-            "apiVersion": {
-              "const": "v3"
-            }, 
-            "kind": {
-              "const": "queue"
-            }
-          }
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/queue.schema.json"
-        }
-      ]
-    },
-    {
-      "allOf": [
-        {
-          "properties": {
-            "apiVersion": {
-              "const": "v3"
-            }, 
-            "kind": {
-              "const": "datastore"
-            }
-          }
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/datastore.schema.json"
-        }
-      ]
-    },    
-    {
-      "allOf": [
-        {
-          "properties": {
-            "apiVersion": {
-              "const": "v3"
-            }, 
-            "kind": {
-              "const": "system"
-            }
-          }
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/system.schema.json"
-        }
-      ]
     }
   ]
 }

--- a/service-catalog/service.schema.json
+++ b/service-catalog/service.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/service.schema.json",
-  "title": "Service Definition Versions [v1, v2, v2.1, v2.2]",
+  "title": "Service Definition Versions [v1, v2, v2.1, v2.2, v3]",
   "oneOf": [
     {
       "allOf": [


### PR DESCRIPTION
 Fix discrepancies when customers are creating definitions using either file name by making sure the two files (`entity.schema.json`, `service.schema.json`) are in parity.

This includes:
* Adding v2 IDE completion/validation to `entity.schema.json`

Will address adding v3 IDE completion/validation to `service.schema.json` in a separate PR

After investigation: 
* v3 schemas are already supported in both `entity.schema.json` and `service.schema.json`.
* v2 schemas are already supported in both `entity.schema.json` and `service.schema.json`.

Details in the comments of the ticket [here](https://datadoghq.atlassian.net/browse/SER-601?focusedCommentId=1937213)
