### PR TITLE
[SER-601] Add v3 IDE completion/validation to service.schema.json

### DIFF
--- a/service-catalog/service.schema.json
+++ b/service-catalog/service.schema.json
@@ -58,6 +58,74 @@
           "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v2.2/schema.json"
         }
       ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "service"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/service.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "queue"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/queue.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "datastore"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/datastore.schema.json"
+        }
+      ]
+    },    
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "system"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/system.schema.json"
+        }
+      ]
     }
   ]
 }

--- a/service-catalog/service.schema.json
+++ b/service-catalog/service.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/service.schema.json",
-  "title": "Service Definition Versions [v1, v2, v2.1, v2.2]",
+  "title": "Service Definition Versions [v1, v2, v2.1, v2.2, v3]",
   "oneOf": [
     {
       "allOf": [


### PR DESCRIPTION
Fix discrepancies when customers are creating definitions using either file name by making sure the two files (`entity.schema.json`, `service.schema.json`) are in parity.

Continuation on [PR](https://github.com/DataDog/schema/pull/67/files):
* This PR adds v3 IDE completion/validation to `service.schema.json`