### PR TITLE
Add kind API to entity.schema.json

### DIFF
--- a/service-catalog/entity.schema.json
+++ b/service-catalog/entity.schema.json
@@ -95,7 +95,24 @@
           "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/datastore.schema.json"
         }
       ]
-    },    
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "const": "v3"
+            }, 
+            "kind": {
+              "const": "api"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/api.schema.json"
+        }
+      ]
+    },
     {
       "allOf": [
         {


### PR DESCRIPTION
Fixing https://github.com/DataDog/schema/issues/72 - looks like we added an API schema, but never made it part of the main entity schema.