### PR TITLE
Add configuration for IaC scanner as version 1.2

### DIFF
--- a/code-security/README.md
+++ b/code-security/README.md
@@ -1,5 +1,8 @@
 # Schemas
 
+## v1.2
+* Add IaC scanner configuration.
+
 ## v1.1
 * Add SCA `ignore-paths` configuration
 

--- a/code-security/iac/v1.2/schema.json
+++ b/code-security/iac/v1.2/schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iac/v1.2/schema.json",
+  "title": "Datadog IaC Configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ignore-rules": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "A list of rule IDs that will not be applied in scans."
+    },
+    "use-rules": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "A list of rule IDs that will be applied in scans. If specified, only these rules will be used (unless other configuration causes them to be ignored)."
+    },
+    "global-config": {
+      "$ref": "#/$defs/globalConfig",
+      "description": "Global settings for the IaC scanner."
+    }
+  },
+  "$defs": {
+    "globalConfig": {
+      "type": "object",
+      "properties": {
+        "ignore-paths": {
+          "$ref": "#/$defs/pathList",
+          "description": "A list of pathnames and glob patterns for files and directories that should not be scanned."
+        },
+        "only-paths": {
+          "$ref": "#/$defs/pathList",
+          "description": "A list of pathnames and glob patterns; only files and directories matching those patterns will be scanned."
+        },
+        "ignore-severities": {
+          "$ref": "#/$defs/severityList",
+          "description": "A list of severities; findings matching one of these severities will not be reported."
+        },
+        "only-severities": {
+          "$ref": "#/$defs/severityList",
+          "description": "A list of severities; only findings matching one of these severities will be reported."
+        },
+        "ignore-categories": {
+          "$ref": "#/$defs/categoryList",
+          "description": "A list of categories; findings matching one of these categories will not be reported."
+        },
+        "only-categories": {
+          "$ref": "#/$defs/categoryList",
+          "description": "A list of categories; only findings matching one of those categories will be reported."
+        }
+      },
+      "additionalProperties": false
+    },
+    "pathList": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "List of file paths or glob patterns."
+    },
+    "severity": {
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info",
+        "CRITICAL",
+        "HIGH",
+        "MEDIUM",
+        "LOW",
+        "INFO"
+      ]
+    },
+    "severityList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/severity"
+      }
+    },
+    "category": {
+      "enum": [
+        "Access Control",
+        "Availability",
+        "Backup",
+        "Best Practices",
+        "Bill Of Materials",
+        "Build Process",
+        "Encryption",
+        "Insecure Configurations",
+        "Insecure Defaults",
+        "Networking and Firewall",
+        "Observability",
+        "Resource Management",
+        "Secret Management",
+        "Structure and Semantics",
+        "Supply-Chain"
+      ]
+    },
+    "categoryList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/category"
+      }
+    }
+  }
+}

--- a/code-security/iac/v1.2/schema.json
+++ b/code-security/iac/v1.2/schema.json
@@ -8,16 +8,14 @@
     "ignore-rules": {
       "type": "array",
       "items": {
-        "type": "string",
-        "minLength": 1
+        "type": "string"
       },
       "description": "A list of rule IDs that will not be applied in scans."
     },
     "use-rules": {
       "type": "array",
       "items": {
-        "type": "string",
-        "minLength": 1
+        "type": "string"
       },
       "description": "A list of rule IDs that will be applied in scans. If specified, only these rules will be used (unless other configuration causes them to be ignored)."
     },
@@ -60,8 +58,7 @@
     "pathList": {
       "type": "array",
       "items": {
-        "type": "string",
-        "minLength": 1
+        "type": "string"
       },
       "description": "List of file paths or glob patterns."
     },

--- a/code-security/iac/v1.2/schema.json
+++ b/code-security/iac/v1.2/schema.json
@@ -71,12 +71,7 @@
         "high",
         "medium",
         "low",
-        "info",
-        "CRITICAL",
-        "HIGH",
-        "MEDIUM",
-        "LOW",
-        "INFO"
+        "info"
       ]
     },
     "severityList": {

--- a/code-security/iac/v1.2/validation.schema.json
+++ b/code-security/iac/v1.2/validation.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iac/v1.2/validation.schema.json",
+  "title": "Datadog IaC Configuration Validation",
+  "description": "Validation for v1.x",
+  "type": "object",
+  "required": ["schema-version"],
+  "additionalProperties": false,
+  "properties": {
+    "schema-version": {
+      "type": "string",
+      "pattern": "^v1\\.\\d+$"
+    },
+    "sast": {},
+    "secrets": {},
+    "iac": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iac/v1.2/schema.json"
+    },
+    "sca": {},
+    "iast": {}
+  }
+}

--- a/code-security/schema.json
+++ b/code-security/schema.json
@@ -8,6 +8,9 @@
     },
     {
       "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.1/schema.json"
+    },
+    {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.2/schema.json"
     }
   ]
 }

--- a/code-security/versions/v1.2/schema.json
+++ b/code-security/versions/v1.2/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.2/schema.json",
+  "title": "Datadog Code Security Configuration v1.2",
+  "type": "object",
+  "required": ["schema-version"],
+  "additionalProperties": false,
+  "properties": {
+    "schema-version": {
+      "type": "string",
+      "const": "v1.2"
+    },
+    "sast": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sast/v1.0/schema.json"
+    },
+    "secrets": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.0/schema.json"
+    },
+    "iac": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iac/v1.2/schema.json"
+    },
+    "sca": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sca/v1.1/schema.json"
+    },
+    "iast": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iast/v1.0/schema.json"
+    }
+  }
+}


### PR DESCRIPTION
Adds support for the `iac` section containing the configuration for the [Datadog IaC scanner](https://github.com/DataDog/datadog-iac-scanner)