### PR TITLE
✨ Add code-security/scfw v1.0 schema for SCFW policy configuration

### DIFF
--- a/code-security/scfw/v1.0/schema.json
+++ b/code-security/scfw/v1.0/schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/scfw/v1.0/schema.json",
+  "title": "Datadog SCFW Policy Configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema-version"],
+  "properties": {
+    "schema-version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Configuration schema version."
+    },
+    "behaviours": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "non_interactive_block_on_warning": {
+          "type": "boolean",
+          "default": true,
+          "description": "On non interactive setup such as CI pipelines, define whether it should block or allow"
+        },
+        "recent_packages_behaviour": {
+          "type": "string",
+          "enum": ["block", "warn", "allow"],
+          "default": "block",
+          "description": "Define whether we should block, warn or allow when installing a package which has been published less than recent_package_timeout ago"
+        },
+        "recent_package_timeout": {
+          "type": "integer",
+          "default": 86400,
+          "description": "The number of second during which we consider a package recent."
+        }
+      }
+    },
+    "policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "block": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/policyRule"
+          }
+        },
+        "allow": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/policyRule"
+          }
+        },
+        "warn": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/policyRule"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "policyRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ecosystem", "package_name", "package_version"],
+      "properties": {
+        "ecosystem": {
+          "type": "string",
+          "enum": ["npm", "pypi"]
+        },
+        "package_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "package_version": {
+          "type": "string",
+          "format": "regex",
+          "description": "A regex describing which versions should be impacted",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/code-security/scfw/v1.0/validation.schema.json
+++ b/code-security/scfw/v1.0/validation.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/scfw/v1.0/validation.schema.json",
+  "title": "Datadog SCFW Policy Configuration Validation",
+  "description": "Validation for v1.x",
+  "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/scfw/v1.0/schema.json"
+}


### PR DESCRIPTION
## 🚀 Motivation
The SCFW (Supply Chain Firewall) feature requires a public, versioned JSON Schema so that consumers (editors, CI tooling, the policy API) can validate policy configuration files against a canonical definition.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | RFC-1105
Incident | N/A
Jira Ticket | [K9CODESEC-2645](https://datadoghq.atlassian.net/browse/K9CODESEC-2645)

## 📝 Summary
- Added `code-security/scfw/v1.0/schema.json`: a faithful replica of the internal SCFW policy schema (`static-analysis-sca-api/internal/scfwpolicy/schema.json`), with the `$id` updated to the canonical GitHub raw URL. It describes the full policy config structure — `schema-version`, `behaviours` (non-interactive blocking, recent-package timeout), and `policies` (block/allow/warn lists of ecosystem-scoped package rules).
- Added `code-security/scfw/v1.0/validation.schema.json`: a thin validation entry-point following the repo convention. Because the SCFW policy is a standalone config file (not a sub-key of the shared code-security config envelope), the validation schema is a direct `$ref` to the versioned schema rather than a multi-section wrapper.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:

[K9CODESEC-2645]: https://datadoghq.atlassian.net/browse/K9CODESEC-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ