### PR TITLE
refactor: change service-catalog to idp in CO

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,9 @@
 # and another team can own the rest of the directory.
 
 # All your base
-*                       @DataDog/service-catalog @DataDog/k9-vm-code-security
+*                       @DataDog/idp @DataDog/k9-vm-code-security
 
 ## Subdirectories
 /datadog-ci             @DataDog/datadog-ci-admins
-/service-catalog        @DataDog/service-catalog
+/service-catalog        @DataDog/idp
 /semantic-core          @DataDog/semantic-core


### PR DESCRIPTION
## Motivation

The service-catalog team has been renamed to IDP and has lost access to this repo, see [this message](https://dd.slack.com/archives/C07P0EJ53CH/p1784671825119609). They need the `CODEOWNER` file to be changed.

## Changes

* Changed service-catalog to IDP within the `CODEOWNER` file