### PR TITLE
Add global-config to secrets scanning schema (v1.5)

### DIFF
--- a/code-security/README.md
+++ b/code-security/README.md
@@ -1,5 +1,14 @@
 # Schemas
 
+## v1.5
+* Add secrets scanner `global-config` (`ignore-paths`, `only-paths`, `use-gitignore`, `ignore-generated-files`, `max-file-size-kb`)
+
+## v1.4
+* Add `arguments` to IaC rule configuration
+
+## v1.3
+* Add `rule-configs`, `ignore-platforms`, and `only-platforms` to IaC configuration
+
 ## v1.2
 * Add IaC scanner configuration.
 

--- a/code-security/schema.json
+++ b/code-security/schema.json
@@ -17,6 +17,9 @@
     },
     {
       "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.4/schema.json"
+    },
+    {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.5/schema.json"
     }
   ]
 }

--- a/code-security/secrets/v1.5/schema.json
+++ b/code-security/secrets/v1.5/schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.5/schema.json",
+  "title": "Datadog Secrets Scanning Configuration",
+  "type": "object",
+  "properties": {
+    "global-config": {
+      "$ref": "#/$defs/globalConfig",
+      "description": "Global settings for the secrets scanner."
+    }
+  },
+  "required": [],
+  "additionalProperties": false,
+  "$defs": {
+    "globalConfig": {
+      "type": "object",
+      "properties": {
+        "only-paths": {
+          "$ref": "#/$defs/pathList",
+          "description": "A list of pathnames and glob patterns; only files and directories matching those patterns will be scanned."
+        },
+        "ignore-paths": {
+          "$ref": "#/$defs/pathList",
+          "description": "A list of pathnames and glob patterns; files and directories matching those patterns will not be scanned."
+        },
+        "use-gitignore": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use .gitignore to exclude files. Defaults to true."
+        },
+        "ignore-generated-files": {
+          "type": "boolean",
+          "default": true,
+          "description": "Ignore generated files. Defaults to true."
+        },
+        "max-file-size-kb": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "pathList": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "List of file paths or glob patterns."
+    }
+  }
+}

--- a/code-security/secrets/v1.5/validation.schema.json
+++ b/code-security/secrets/v1.5/validation.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.5/validation.schema.json",
+  "title": "Datadog Secrets Scanning Configuration Validation",
+  "description": "Validation for v1.x",
+  "type": "object",
+  "required": ["schema-version"],
+  "additionalProperties": false,
+  "properties": {
+    "schema-version": {
+      "type": "string",
+      "pattern": "^v1\\.\\d+$"
+    },
+    "sast": {},
+    "secrets": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.5/schema.json"
+    },
+    "iac": {},
+    "sca": {},
+    "iast": {}
+  }
+}

--- a/code-security/versions/v1.5/schema.json
+++ b/code-security/versions/v1.5/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.5/schema.json",
+  "title": "Datadog Code Security Configuration v1.5",
+  "type": "object",
+  "required": ["schema-version"],
+  "additionalProperties": false,
+  "properties": {
+    "schema-version": {
+      "type": "string",
+      "const": "v1.5"
+    },
+    "sast": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sast/v1.0/schema.json"
+    },
+    "secrets": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.5/schema.json"
+    },
+    "iac": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iac/v1.4/schema.json"
+    },
+    "sca": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sca/v1.1/schema.json"
+    },
+    "iast": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iast/v1.0/schema.json"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `global-config` block to the secrets scanning schema with `ignore-paths`, `only-paths`, `use-gitignore`, `ignore-generated-files`, and `max-file-size-kb`, matching the existing SAST convention.
- Publish this as schema v1.5.
- Backfill missing v1.3/v1.4 changelog entries in `code-security/README.md` while touching this area.

## Test plan
- [x] JSON Schema files validated as syntactically correct