### PR TITLE
(integrations) Add service terraform schema support

### DIFF
--- a/service-catalog/v3/integration_terraform.schema.json
+++ b/service-catalog/v3/integration_terraform.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_terraform.schema.json",
+  "type": "object",
+  "description": "An HCP Terraform integration schema",
+  "required": ["workspaceIds"],
+  "additionalProperties": false,
+  "properties": {
+    "workspaceIds": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^ws-[a-zA-Z0-9]+$"
+      },
+      "minItems": 1,
+      "description": "The HCP Terraform workspace IDs linked to this service."
+    }
+  }
+}

--- a/service-catalog/v3/integrations.schema.json
+++ b/service-catalog/v3/integrations.schema.json
@@ -8,6 +8,7 @@
     "pagerduty": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_pagerduty.schema.json"},
     "opsgenie": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_opsgenie.schema.json"},
     "jiraServiceManagementOps": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_jsm_ops.schema.json"},
-    "sentry": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_sentry.schema.json"}
+    "sentry": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_sentry.schema.json"},
+    "terraform": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_terraform.schema.json"}
   }
 }


### PR DESCRIPTION
Mirrors the internal HCP Terraform integration field (`integrations.terraform.workspaceIds`) into the public v3 service definition schema, same pattern as pagerduty/opsgenie/jsm_ops/sentry (see #99 for the jsm_ops precedent).

- Adds `integration_terraform.schema.json`: an object with `workspaceIds`, an array of workspace IDs matching the `ws-<alphanumeric>` format already validated in the editor.
- Registers `terraform` in `integrations.schema.json`.

`workspaceIds` is required with `minItems: 1`, following the same convention as `sentry.projectSlugs` — the integration block is only ever written when at least one workspace is linked.