### PR TITLE
♻️ Align SCFW policy schema with static-analysis-sca-api

### DIFF
--- a/code-security/scfw/v1.0/schema.json
+++ b/code-security/scfw/v1.0/schema.json
@@ -48,12 +48,6 @@
           "items": {
             "$ref": "#/$defs/policyRule"
           }
-        },
-        "warn": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/policyRule"
-          }
         }
       }
     }
@@ -74,8 +68,7 @@
         },
         "package_version": {
           "type": "string",
-          "format": "regex",
-          "description": "A regex describing which versions should be impacted",
+          "description": "A glob describing which versions should be impacted",
           "minLength": 1
         }
       }


### PR DESCRIPTION
## 🚀 Motivation
Package versions in the SCFW policy were matched using regexes, but Go and JavaScript regex engines have subtly different behaviors, making the JSON-schema validation unreliable, and regexes are hard for humans to write and read. Since the policy hasn't reached customers yet, we can make this change freely and move to globs, which are easier to write and understand while retaining most of the flexibility of regexes.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [K9CODESEC-4499](https://datadoghq.atlassian.net/browse/K9CODESEC-4499)

## 📝 Summary
- Changed `package_version` in the SCFW policy schema from a regex-formatted string to a glob-described string, aligning validation semantics with `static-analysis-sca-api` and removing the go/JS regex mismatch risk.
- Removed the unused `warn` policy rule array from the SCFW policy definition to keep the schema aligned with `static-analysis-sca-api`.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:


[K9CODESEC-4499]: https://datadoghq.atlassian.net/browse/K9CODESEC-4499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ