### PR TITLE
Add experimental-ast-filter to secrets configuration (v1.6)

### DIFF
--- a/code-security/README.md
+++ b/code-security/README.md
@@ -1,5 +1,8 @@
 # Schemas
 
+## v1.6
+* Add secrets scanner `experimental-ast-filter` configuration
+
 ## v1.5
 * Add secrets scanner `global-config` (`ignore-paths`, `only-paths`, `use-gitignore`, `ignore-generated-files`, `max-file-size-kb`)
 

--- a/code-security/schema.json
+++ b/code-security/schema.json
@@ -20,6 +20,9 @@
     },
     {
       "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.5/schema.json"
+    },
+    {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.6/schema.json"
     }
   ]
 }

--- a/code-security/secrets/v1.6/schema.json
+++ b/code-security/secrets/v1.6/schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.6/schema.json",
+  "title": "Datadog Secrets Scanning Configuration",
+  "type": "object",
+  "properties": {
+    "global-config": {
+      "$ref": "#/$defs/globalConfig",
+      "description": "Global settings for the secrets scanner."
+    },
+    "experimental-ast-filter": {
+      "type": "boolean",
+      "description": "Enable experimental AST-based filtering for secret scanning."
+    }
+  },
+  "required": [],
+  "additionalProperties": false,
+  "$defs": {
+    "globalConfig": {
+      "type": "object",
+      "properties": {
+        "only-paths": {
+          "$ref": "#/$defs/pathList",
+          "description": "A list of pathnames and glob patterns; only files and directories matching those patterns will be scanned."
+        },
+        "ignore-paths": {
+          "$ref": "#/$defs/pathList",
+          "description": "A list of pathnames and glob patterns; files and directories matching those patterns will not be scanned."
+        },
+        "use-gitignore": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use .gitignore to exclude files. Defaults to true."
+        },
+        "ignore-generated-files": {
+          "type": "boolean",
+          "default": true,
+          "description": "Ignore generated files. Defaults to true."
+        },
+        "max-file-size-kb": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "pathList": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "List of file paths or glob patterns."
+    }
+  }
+}

--- a/code-security/secrets/v1.6/validation.schema.json
+++ b/code-security/secrets/v1.6/validation.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.6/validation.schema.json",
+  "title": "Datadog Secrets Scanning Configuration Validation",
+  "description": "Validation for v1.x",
+  "type": "object",
+  "required": ["schema-version"],
+  "additionalProperties": false,
+  "properties": {
+    "schema-version": {
+      "type": "string",
+      "pattern": "^v1\\.\\d+$"
+    },
+    "sast": {},
+    "secrets": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.6/schema.json"
+    },
+    "iac": {},
+    "sca": {},
+    "iast": {}
+  }
+}

--- a/code-security/versions/v1.6/schema.json
+++ b/code-security/versions/v1.6/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.6/schema.json",
+  "title": "Datadog Code Security Configuration v1.6",
+  "type": "object",
+  "required": ["schema-version"],
+  "additionalProperties": false,
+  "properties": {
+    "schema-version": {
+      "type": "string",
+      "const": "v1.6"
+    },
+    "sast": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sast/v1.0/schema.json"
+    },
+    "secrets": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.6/schema.json"
+    },
+    "iac": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iac/v1.4/schema.json"
+    },
+    "sca": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sca/v1.1/schema.json"
+    },
+    "iast": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iast/v1.0/schema.json"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Follows the runbook in [Code Security Unified Configuration](https://datadoghq.atlassian.net/wiki/spaces/Vulnerabil/pages/6397592288/Code+Security+Unified+Configuration) (Confluence) for a minor version bump scoped to a single product.
- Adds a new top-level boolean setting `experimental-ast-filter` to the `secrets` product configuration, to gate experimental AST-based filtering for secret scanning.
- Bumps `secrets` and the global `schema-version` from v1.5 to v1.6 (all other products keep referencing their current minor version, per the runbook's minor-version semantics).

## Changes
- `code-security/secrets/v1.6/schema.json` (new): copied from v1.5, added `experimental-ast-filter` (boolean) alongside `global-config`
- `code-security/secrets/v1.6/validation.schema.json` (new): copied from v1.5, `secrets.$ref` updated to v1.6
- `code-security/versions/v1.6/schema.json` (new): copied from v1.5, `schema-version.const` and `secrets.$ref` bumped to v1.6
- `code-security/schema.json`: added `oneOf` entry for `versions/v1.6/schema.json`
- `code-security/README.md`: added v1.6 changelog entry


## Related PR
 - [datadog-static-analyzer](https://github.com/DataDog/datadog-static-analyzer/pull/953)
 - [dd-source](https://github.com/ddoghq/dd-source/pull/77375)

## Test plan
- [x] All new/modified JSON files validated as syntactically correct
- [x] Diffed `versions/v1.5/schema.json` vs `versions/v1.6/schema.json` to confirm only the `secrets` ref and version markers changed
- [x] Validated a sample config with `experimental-ast-filter: true` against `secrets/v1.6/schema.json` using `jsonschema` — passes
- [x] Confirmed a non-boolean value for `experimental-ast-filter` and an unknown top-level key are both rejected (`additionalProperties: false` preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)