### PR TITLE
[K9CODESEC-5955] `code-security`: Add v1.7 schema for SCA (ignore-ecosystems, ignore-packages)

### DIFF
--- a/code-security/README.md
+++ b/code-security/README.md
@@ -1,5 +1,8 @@
 # Schemas
 
+## v1.7
+* Add SCA `ignore-ecosystems` and `ignore-packages` configuration
+
 ## v1.6
 * Add secrets scanner `experimental-ast-filter` configuration
 

--- a/code-security/sca/v1.7/schema.json
+++ b/code-security/sca/v1.7/schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sca/v1.7/schema.json",
+  "title": "Datadog SCA Configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ignore-paths": {
+      "$ref": "#/$defs/pathList",
+      "description": "List of file paths or glob patterns to exclude from SCA scanning."
+    },
+    "ignore-ecosystems": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ecosystem" },
+      "description": "List of ecosystems to exclude entirely from SCA scanning. Manifests belonging to a matching ecosystem are never parsed."
+    },
+    "ignore-packages": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/packageRef" },
+      "description": "List of packages to exclude from SCA scanning, in the form <ecosystem>:<name> (e.g. npm:lodash). Matches the package under that ecosystem regardless of version."
+    }
+  },
+  "$defs": {
+    "pathList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "List of file paths or glob patterns."
+    },
+    "ecosystem": {
+      "type": "string",
+      "enum": [
+        "Go",
+        "npm",
+        "OSS-Fuzz",
+        "PyPI",
+        "RubyGems",
+        "crates.io",
+        "Packagist",
+        "Maven",
+        "NuGet",
+        "Linux",
+        "Debian",
+        "Alpine",
+        "Hex",
+        "Android",
+        "GitHub Actions",
+        "Pub",
+        "ConanCenter",
+        "Rocky Linux",
+        "AlmaLinux",
+        "Bitnami",
+        "Photon OS",
+        "CRAN",
+        "Bioconductor",
+        "SwiftURL"
+      ]
+    },
+    "packageRef": {
+      "type": "string",
+      "pattern": "^[^:]+:.+$",
+      "minLength": 1,
+      "description": "A package identifier in the form <ecosystem>:<name>."
+    }
+  }
+}

--- a/code-security/sca/v1.7/schema.json
+++ b/code-security/sca/v1.7/schema.json
@@ -57,9 +57,9 @@
     },
     "packageRef": {
       "type": "string",
-      "pattern": "^[^:]+:.+$",
+      "pattern": "^(Go|npm|OSS-Fuzz|PyPI|RubyGems|crates\\.io|Packagist|Maven|NuGet|Linux|Debian|Alpine|Hex|Android|GitHub Actions|Pub|ConanCenter|Rocky Linux|AlmaLinux|Bitnami|Photon OS|CRAN|Bioconductor|SwiftURL):.+$",
       "minLength": 1,
-      "description": "A package identifier in the form <ecosystem>:<name>."
+      "description": "A package identifier in the form <ecosystem>:<name>, where <ecosystem> must match one of the values in the ecosystem enum."
     }
   }
 }

--- a/code-security/sca/v1.7/validation.schema.json
+++ b/code-security/sca/v1.7/validation.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sca/v1.7/validation.schema.json",
+  "title": "Datadog SCA Configuration Validation",
+  "description": "Validation for v1.x",
+  "type": "object",
+  "required": ["schema-version"],
+  "additionalProperties": false,
+  "properties": {
+    "schema-version": {
+      "type": "string",
+      "pattern": "^v1\\.\\d+$"
+    },
+    "sast": {},
+    "secrets": {},
+    "iac": {},
+    "sca": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sca/v1.7/schema.json"
+    },
+    "iast": {}
+  }
+}

--- a/code-security/schema.json
+++ b/code-security/schema.json
@@ -23,6 +23,9 @@
     },
     {
       "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.6/schema.json"
+    },
+    {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.7/schema.json"
     }
   ]
 }

--- a/code-security/versions/v1.7/schema.json
+++ b/code-security/versions/v1.7/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/versions/v1.7/schema.json",
+  "title": "Datadog Code Security Configuration v1.7",
+  "type": "object",
+  "required": ["schema-version"],
+  "additionalProperties": false,
+  "properties": {
+    "schema-version": {
+      "type": "string",
+      "const": "v1.7"
+    },
+    "sast": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sast/v1.0/schema.json"
+    },
+    "secrets": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/secrets/v1.6/schema.json"
+    },
+    "iac": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iac/v1.4/schema.json"
+    },
+    "sca": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/sca/v1.7/schema.json"
+    },
+    "iast": {
+      "$ref": "https://raw.githubusercontent.com/DataDog/schema/main/code-security/iast/v1.0/schema.json"
+    }
+  }
+}


### PR DESCRIPTION
Adds a new schema version to support the `ignore-ecosystems` and `ignore-packages` fields for the SCA product - follows the runbook [here](https://datadoghq.atlassian.net/wiki/spaces/Vulnerabil/pages/6397592288/Code+Security+Unified+Configuration#1a.-Add-SCA-to-JSON-Schema) to make the appropriate changes.

For context on how the fields will be used refer to the [RFC](https://docs.google.com/document/d/1vmVHuwkkS9Y9gVqJBuaZpZXdE8mar4tDvZQUBePcm1I).

## Testing

Used the `sca/v1.7` schema added here (unified `v1.7` — SCA's per-section version now matches the unified schema-version it was introduced under, same as `secrets/v1.6`) to validate the corresponding `datadog-sbom-generator` implementation end-to-end. Config:
```yaml
schema-version: v1.7
sca:
  ignore-ecosystems:
    - PyPI
  ignore-packages:
    - Go:github.com/urfave/cli/v2
```
was parsed and enforced correctly — PyPI packages and `urfave/cli/v2` excluded from the generated SBOM, all other packages unaffected. See DataDog/datadog-sbom-generator#236, #237, #238 for the implementation-side test detail.

Jira: [K9CODESEC-5955](https://datadoghq.atlassian.net/browse/K9CODESEC-5955)

[K9CODESEC-5955]: https://datadoghq.atlassian.net/browse/K9CODESEC-5955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Review fixes
- `packageRef`'s pattern now cross-validates the `<ecosystem>` prefix against the `ecosystem` enum (was previously just `^[^:]+:.+$`, accepting any non-empty prefix), so an unknown or mis-cased ecosystem in `ignore-packages` fails schema validation instead of only warning at scan time.
- Renamed `sca/v1.2` to `sca/v1.7` and fixed the internal `$id`/`$ref` paths (in `sca/v1.7/schema.json`, `sca/v1.7/validation.schema.json`, and `versions/v1.7/schema.json`) — SCA's section version must match the unified schema-version it ships under, as with every other section (e.g. `secrets/v1.6` under unified `v1.6`).