### PR TITLE
Add Least Privilege to IaC config category enum

### DIFF
--- a/code-security/iac/v1.2/schema.json
+++ b/code-security/iac/v1.2/schema.json
@@ -88,6 +88,7 @@
         "Encryption",
         "Insecure Configurations",
         "Insecure Defaults",
+        "Least Privilege",
         "Networking and Firewall",
         "Observability",
         "Resource Management",

--- a/code-security/iac/v1.3/schema.json
+++ b/code-security/iac/v1.3/schema.json
@@ -125,6 +125,7 @@
         "Encryption",
         "Insecure Configurations",
         "Insecure Defaults",
+        "Least Privilege",
         "Networking and Firewall",
         "Observability",
         "Resource Management",

--- a/code-security/iac/v1.4/schema.json
+++ b/code-security/iac/v1.4/schema.json
@@ -166,6 +166,7 @@
         "Encryption",
         "Insecure Configurations",
         "Insecure Defaults",
+        "Least Privilege",
         "Networking and Firewall",
         "Observability",
         "Resource Management",


### PR DESCRIPTION
## Motivation

Add **Least Privilege** to the IaC config JSON Schema category enum so `ignore-categories` / `only-categories` validate in IDE and config tooling.

Slack: https://dd.slack.com/archives/C069XJF7F4L/p1788182857176039

## Changes

- Add `"Least Privilege"` to `$defs/category.enum` in `code-security/iac/v1.2/schema.json` and `v1.3/schema.json`
