### PR TITLE
Add service ServiceNow schema support

### DIFF
--- a/service-catalog/v3/integration_servicenow.schema.json
+++ b/service-catalog/v3/integration_servicenow.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_servicenow.schema.json",
+  "type": "object",
+  "description": "A ServiceNow integration schema",
+  "required": ["serviceURL"],
+  "additionalProperties": false,
+  "properties": {
+    "serviceURL": {
+      "type": "string",
+      "pattern": "^https?://[a-zA-Z0-9][a-zA-Z0-9-]*\\.service-now\\.com/.*sys_id(=|%3[Dd])[a-fA-F0-9]{32}",
+      "description": "The URL of the ServiceNow service that owns this service. To obtain this value, in ServiceNow go to All > Service Portfolio Management > Services, click the service, then copy the URL from your browser's address bar. That URL contains both the ServiceNow instance and the service's sys_id, which are the two values Datadog reads from it. The instance is needed because a sys_id is only unique within a single instance, and an organization can connect more than one."
+    }
+  }
+}

--- a/service-catalog/v3/integrations.schema.json
+++ b/service-catalog/v3/integrations.schema.json
@@ -9,6 +9,7 @@
     "opsgenie": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_opsgenie.schema.json"},
     "jiraServiceManagementOps": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_jsm_ops.schema.json"},
     "sentry": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_sentry.schema.json"},
-    "terraform": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_terraform.schema.json"}
+    "terraform": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_terraform.schema.json"},
+    "servicenow": {"$ref": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/integration_servicenow.schema.json"}
   }
 }


### PR DESCRIPTION
Adds the ServiceNow integration to the public v3 service catalog schema, so a `servicenow` block in a service definition validates instead of erroring as an unknown property.

Mirrors the existing integrations — same shape as `integration_jsm_ops` (#99), `integration_sentry` and `integration_terraform`.

- `service-catalog/v3/integration_servicenow.schema.json` (new) — one required `serviceURL` property
- `service-catalog/v3/integrations.schema.json` — register it under `servicenow`

The `serviceURL` pattern requires a `*.service-now.com` URL containing a 32-character hex `sys_id`. Both values are read from it: the instance and the service's `sys_id`. The instance matters because a `sys_id` is only unique within one instance, and an organization can connect more than one.

Example of what now validates:

```yaml
integrations:
  servicenow:
    serviceURL: https://my-instance.service-now.com/now/nav/ui/classic/params/target/cmdb_ci_service.do%3Fsys_id%3D8166953c33de0314946d955a7e5c7bad
```